### PR TITLE
The ?reconnect option actually belongs to mysql

### DIFF
--- a/sqlengine/postgres_engine.go
+++ b/sqlengine/postgres_engine.go
@@ -171,7 +171,7 @@ func (d *PostgresEngine) RevokePrivileges(dbname string, username string) error 
 }
 
 func (d *PostgresEngine) URI(address string, port int64, dbname string, username string, password string) string {
-	return fmt.Sprintf("postgres://%s:%s@%s:%d/%s?reconnect=true", username, password, address, port, dbname)
+	return fmt.Sprintf("postgres://%s:%s@%s:%d/%s", username, password, address, port, dbname)
 }
 
 func (d *PostgresEngine) JDBCURI(address string, port int64, dbname string, username string, password string) string {


### PR DESCRIPTION
This is an artifact of the postgres/mysql support being split and not tested, it will cause postgres connections to fail.
