### PR TITLE
Disable RDS backups by default (workaround)

### DIFF
--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -669,12 +669,10 @@ func (b *RDSBroker) dbInstanceFromPlan(servicePlan ServicePlan) *awsrds.DBInstan
 	dbInstanceDetails.PubliclyAccessible = servicePlan.RDSProperties.PubliclyAccessible
 
 	if strings.ToLower(servicePlan.RDSProperties.Engine) != "aurora" {
+		dbInstanceDetails.BackupRetentionPeriod = servicePlan.RDSProperties.BackupRetentionPeriod
+
 		if servicePlan.RDSProperties.AllocatedStorage > 0 {
 			dbInstanceDetails.AllocatedStorage = servicePlan.RDSProperties.AllocatedStorage
-		}
-
-		if servicePlan.RDSProperties.BackupRetentionPeriod > 0 {
-			dbInstanceDetails.BackupRetentionPeriod = servicePlan.RDSProperties.BackupRetentionPeriod
 		}
 
 		if servicePlan.RDSProperties.CharacterSetName != "" {

--- a/rdsbroker/broker_test.go
+++ b/rdsbroker/broker_test.go
@@ -344,6 +344,14 @@ var _ = Describe("RDS Broker", func() {
 			})
 		})
 
+		Context("when has default BackupRetentionPeriod", func() {
+			It("has backups turned off", func() {
+				_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+				Expect(dbInstance.CreateDBInstanceDetails.BackupRetentionPeriod).To(Equal(int64(0)))
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
 		Context("when has CharacterSetName", func() {
 			BeforeEach(func() {
 				rdsProperties1.CharacterSetName = "test-characterset-name"


### PR DESCRIPTION
Some facts:
- We wish to have the ability to disable RDS backups.
- Disabling RDS backups is achieved by setting the backup retention period to 0.
- The golang zero value for an Int is 0.
- The RDS broker default value for backup retention is 1.
- The RDS broker allows you to override the backup retention period as
  long as the value is > 0.

Hence, we cannot turn off backups either from a plan or with user-specified parameters.

We decided that having backups default to being off (0) is reasonable as the plans themselves can override this - we may even wish to expose a postgres plan that explicitly does not have backups for testing.

This change simply takes whatever value is defined in the plan rather than requiring it to be > 0, and the plan default is 0 (off).
