### PR TITLE
[#117512371] Allow dbPrefix to include - and _

### DIFF
--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -456,11 +456,11 @@ func (b *RDSBroker) LastOperation(instanceID string) (brokerapi.LastOperationRes
 }
 
 func (b *RDSBroker) dbClusterIdentifier(instanceID string) string {
-	return fmt.Sprintf("%s-%s", b.dbPrefix, strings.Replace(instanceID, "_", "-", -1))
+	return fmt.Sprintf("%s-%s", strings.Replace(b.dbPrefix, "_", "-", -1), strings.Replace(instanceID, "_", "-", -1))
 }
 
 func (b *RDSBroker) dbInstanceIdentifier(instanceID string) string {
-	return fmt.Sprintf("%s-%s", b.dbPrefix, strings.Replace(instanceID, "_", "-", -1))
+	return fmt.Sprintf("%s-%s", strings.Replace(b.dbPrefix, "_", "-", -1), strings.Replace(instanceID, "_", "-", -1))
 }
 
 func (b *RDSBroker) masterUsername() string {
@@ -480,7 +480,7 @@ func (b *RDSBroker) dbPassword() string {
 }
 
 func (b *RDSBroker) dbName(instanceID string) string {
-	return fmt.Sprintf("%s_%s", b.dbPrefix, strings.Replace(instanceID, "-", "_", -1))
+	return fmt.Sprintf("%s_%s", strings.Replace(b.dbPrefix, "-", "_", -1), strings.Replace(instanceID, "-", "_", -1))
 }
 
 func (b *RDSBroker) createDBCluster(instanceID string, servicePlan ServicePlan, provisionParameters ProvisionParameters, details brokerapi.ProvisionDetails) *awsrds.DBClusterDetails {

--- a/rdsbroker/broker_test.go
+++ b/rdsbroker/broker_test.go
@@ -2,6 +2,7 @@ package rdsbroker_test
 
 import (
 	"errors"
+	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -46,6 +47,7 @@ var _ = Describe("RDS Broker", func() {
 		serviceBindable              bool
 		planUpdateable               bool
 		skipFinalSnapshot            bool
+		dbPrefix                     string
 	)
 
 	const (
@@ -65,6 +67,7 @@ var _ = Describe("RDS Broker", func() {
 		serviceBindable = true
 		planUpdateable = true
 		skipFinalSnapshot = true
+		dbPrefix = "cf"
 
 		dbInstance = &rdsfake.FakeDBInstance{}
 		dbCluster = &rdsfake.FakeDBCluster{}
@@ -127,7 +130,7 @@ var _ = Describe("RDS Broker", func() {
 
 		config = Config{
 			Region:                       "rds-region",
-			DBPrefix:                     "cf",
+			DBPrefix:                     dbPrefix,
 			AllowUserProvisionParameters: allowUserProvisionParameters,
 			AllowUserUpdateParameters:    allowUserUpdateParameters,
 			AllowUserBindParameters:      allowUserBindParameters,
@@ -233,6 +236,21 @@ var _ = Describe("RDS Broker", func() {
 			Expect(dbInstance.CreateDBInstanceDetails.Tags["Organization ID"]).To(Equal("organization-id"))
 			Expect(dbInstance.CreateDBInstanceDetails.Tags["Space ID"]).To(Equal("space-id"))
 			Expect(err).ToNot(HaveOccurred())
+		})
+
+		Context("with a db prefix including - and _", func() {
+			BeforeEach(func() {
+				dbPrefix = "with-dash_underscore"
+			})
+
+			It("makes the proper calls", func() {
+				_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(dbInstance.CreateCalled).To(BeTrue())
+				Expect(dbInstance.CreateID).To(Equal("with-dash-underscore-" + instanceID))
+				expectedDBName := "with_dash_underscore_" + strings.Replace(instanceID, "-", "_", -1)
+				Expect(dbInstance.CreateDBInstanceDetails.DBName).To(Equal(expectedDBName))
+			})
 		})
 
 		Context("when has AllocatedStorage", func() {

--- a/rdsbroker/broker_test.go
+++ b/rdsbroker/broker_test.go
@@ -46,7 +46,9 @@ var _ = Describe("RDS Broker", func() {
 		serviceBindable              bool
 		planUpdateable               bool
 		skipFinalSnapshot            bool
+	)
 
+	const (
 		instanceID           = "instance-id"
 		bindingID            = "binding-id"
 		dbInstanceIdentifier = "cf-instance-id"


### PR DESCRIPTION
RDS DB instance identifiers can't contain an `_`, and db names can't contain a
`-`. Currently generated uuid's have `-` and `_` replaced with the other when
generating the instance ids and db names. This replacement isn't applied
to the dbPrefix, meaning that if it contains either of these characters,
the broker will error when provisioning.

This applies the same replacement logic to the dbPrefix.
