### PR TITLE
Fix for allowing backup_retention_period to be 0

### DIFF
--- a/awsrds/rds_db_instance.go
+++ b/awsrds/rds_db_instance.go
@@ -196,9 +196,7 @@ func (r *RDSDBInstance) buildCreateDBInstanceInput(ID string, dbInstanceDetails 
 		createDBInstanceInput.AvailabilityZone = aws.String(dbInstanceDetails.AvailabilityZone)
 	}
 
-	if dbInstanceDetails.BackupRetentionPeriod > 0 {
-		createDBInstanceInput.BackupRetentionPeriod = aws.Int64(dbInstanceDetails.BackupRetentionPeriod)
-	}
+	createDBInstanceInput.BackupRetentionPeriod = aws.Int64(dbInstanceDetails.BackupRetentionPeriod)
 
 	if dbInstanceDetails.CharacterSetName != "" {
 		createDBInstanceInput.CharacterSetName = aws.String(dbInstanceDetails.CharacterSetName)

--- a/awsrds/rds_db_instance_test.go
+++ b/awsrds/rds_db_instance_test.go
@@ -220,6 +220,7 @@ var _ = Describe("RDS DB Instance", func() {
 				MultiAZ:                 aws.Bool(false),
 				PubliclyAccessible:      aws.Bool(false),
 				StorageEncrypted:        aws.Bool(false),
+				BackupRetentionPeriod:   aws.Int64(0),
 			}
 			createDBInstanceError = nil
 		})


### PR DESCRIPTION
56edf80 (PR #2) Allowed setting the retention period to zero in the broker. It
missed out this extra change in the RDS interface, which also had a
check for > 0. This resulted in the backup_retention_period being set to
`null` in the request to AWS, and the AWS default of 1 day being
applied.

The value in the request to AWS is a null instead of 0 because the
`rds.CreateDBInstanceInput` type defines its `BackupRetentionPeriod`
field as `*int64` instead of `int64`, meaning that the zero value for
this field is nil (which translates to a null in JSON).
