### PR TITLE
[#118479861] Prefix master password generation with a seed

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -18,8 +18,9 @@ var _ = Describe("Config", func() {
 			Username: "broker-username",
 			Password: "broker-password",
 			RDSConfig: rdsbroker.Config{
-				Region:   "rds-region",
-				DBPrefix: "cf",
+				Region:             "rds-region",
+				DBPrefix:           "cf",
+				MasterPasswordSeed: "secret",
 			},
 		}
 	)

--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -38,6 +38,7 @@ var rdsStatus2State = map[string]string{
 
 type RDSBroker struct {
 	dbPrefix                     string
+	masterPasswordSeed           string
 	allowUserProvisionParameters bool
 	allowUserUpdateParameters    bool
 	allowUserBindParameters      bool
@@ -55,6 +56,7 @@ func New(
 ) *RDSBroker {
 	return &RDSBroker{
 		dbPrefix:                     config.DBPrefix,
+		masterPasswordSeed:           config.MasterPasswordSeed,
 		allowUserProvisionParameters: config.AllowUserProvisionParameters,
 		allowUserUpdateParameters:    config.AllowUserUpdateParameters,
 		allowUserBindParameters:      config.AllowUserBindParameters,
@@ -396,7 +398,7 @@ func (b *RDSBroker) masterUsername() string {
 }
 
 func (b *RDSBroker) masterPassword(instanceID string) string {
-	return utils.GetMD5B64(instanceID, defaultPasswordLength)
+	return utils.GetMD5B64(b.masterPasswordSeed+instanceID, defaultPasswordLength)
 }
 
 func (b *RDSBroker) dbUsername(bindingID string) string {

--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -402,7 +402,7 @@ func (b *RDSBroker) masterPassword(instanceID string) string {
 }
 
 func (b *RDSBroker) dbUsername(bindingID string) string {
-	return utils.GetMD5B64(bindingID, defaultUsernameLength)
+	return "u" + strings.Replace(utils.GetMD5B64(bindingID, defaultUsernameLength-1), "-", "_", -1)
 }
 
 func (b *RDSBroker) dbPassword() string {

--- a/rdsbroker/broker_test.go
+++ b/rdsbroker/broker_test.go
@@ -55,8 +55,8 @@ var _ = Describe("RDS Broker", func() {
 		bindingID            = "binding-id"
 		dbInstanceIdentifier = "cf-instance-id"
 		dbName               = "cf_instance_id"
-		dbUsername           = "vMSB820K+t3WvCXd"
-		masterUserPassword   = "qOeiJ6AstR/mUQJxn6jyew=="
+		dbUsername           = "uvMSB820K_t3WvCX"
+		masterUserPassword   = "qOeiJ6AstR_mUQJxn6jyew=="
 	)
 
 	BeforeEach(func() {

--- a/rdsbroker/broker_test.go
+++ b/rdsbroker/broker_test.go
@@ -50,12 +50,13 @@ var _ = Describe("RDS Broker", func() {
 	)
 
 	const (
+		masterPasswordSeed   = "something-secret"
 		instanceID           = "instance-id"
 		bindingID            = "binding-id"
 		dbInstanceIdentifier = "cf-instance-id"
 		dbName               = "cf_instance_id"
 		dbUsername           = "vMSB820K+t3WvCXd"
-		masterUserPassword   = "fq+m6EuWXMsLeLDJZ8tkjA=="
+		masterUserPassword   = "qOeiJ6AstR/mUQJxn6jyew=="
 	)
 
 	BeforeEach(func() {
@@ -128,6 +129,7 @@ var _ = Describe("RDS Broker", func() {
 		config = Config{
 			Region:                       "rds-region",
 			DBPrefix:                     dbPrefix,
+			MasterPasswordSeed:           masterPasswordSeed,
 			AllowUserProvisionParameters: allowUserProvisionParameters,
 			AllowUserUpdateParameters:    allowUserUpdateParameters,
 			AllowUserBindParameters:      allowUserBindParameters,

--- a/rdsbroker/broker_test.go
+++ b/rdsbroker/broker_test.go
@@ -54,8 +54,8 @@ var _ = Describe("RDS Broker", func() {
 		bindingID            = "binding-id"
 		dbInstanceIdentifier = "cf-instance-id"
 		dbName               = "cf_instance_id"
-		dbUsername           = "YmluZGluZy1pZNQd"
-		masterUserPassword   = "aW5zdGFuY2UtaWTUHYzZjwCyBOm"
+		dbUsername           = "vMSB820K+t3WvCXd"
+		masterUserPassword   = "fq+m6EuWXMsLeLDJZ8tkjA=="
 	)
 
 	BeforeEach(func() {

--- a/rdsbroker/config.go
+++ b/rdsbroker/config.go
@@ -8,6 +8,7 @@ import (
 type Config struct {
 	Region                       string  `json:"region"`
 	DBPrefix                     string  `json:"db_prefix"`
+	MasterPasswordSeed           string  `json:"master_password_seed"`
 	AllowUserProvisionParameters bool    `json:"allow_user_provision_parameters"`
 	AllowUserUpdateParameters    bool    `json:"allow_user_update_parameters"`
 	AllowUserBindParameters      bool    `json:"allow_user_bind_parameters"`
@@ -21,6 +22,10 @@ func (c Config) Validate() error {
 
 	if c.DBPrefix == "" {
 		return errors.New("Must provide a non-empty DBPrefix")
+	}
+
+	if c.MasterPasswordSeed == "" {
+		return errors.New("Must provide a non-empty MasterPasswordSeed")
 	}
 
 	if err := c.Catalog.Validate(); err != nil {

--- a/rdsbroker/config_test.go
+++ b/rdsbroker/config_test.go
@@ -12,8 +12,9 @@ var _ = Describe("Config", func() {
 		config Config
 
 		validConfig = Config{
-			Region:   "rds-region",
-			DBPrefix: "cf",
+			Region:             "rds-region",
+			DBPrefix:           "cf",
+			MasterPasswordSeed: "secret",
 			Catalog: Catalog{
 				[]Service{
 					Service{
@@ -50,6 +51,14 @@ var _ = Describe("Config", func() {
 			err := config.Validate()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("Must provide a non-empty DBPrefix"))
+		})
+
+		It("returns error if MasterPasswordSeed is not valid", func() {
+			config.MasterPasswordSeed = ""
+
+			err := config.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Must provide a non-empty MasterPasswordSeed"))
 		})
 
 		It("returns error if Catalog is not valid", func() {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"io"
-	"math"
 )
 
 var alpha = []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz")
@@ -38,8 +37,12 @@ func randChar(length int, chars []byte) string {
 	}
 }
 
-func GetMD5B64(text string, length int) string {
-	hasher := md5.New()
-	md5 := hasher.Sum([]byte(text))
-	return base64.StdEncoding.EncodeToString(md5)[0:int(math.Min(float64(length), float64(len(md5))))]
+func GetMD5B64(text string, maxLength int) string {
+	md5 := md5.Sum([]byte(text))
+	encoded := base64.StdEncoding.EncodeToString(md5[:])
+	if len(encoded) > maxLength {
+		return encoded[0:maxLength]
+	} else {
+		return encoded
+	}
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -39,7 +39,7 @@ func randChar(length int, chars []byte) string {
 
 func GetMD5B64(text string, maxLength int) string {
 	md5 := md5.Sum([]byte(text))
-	encoded := base64.StdEncoding.EncodeToString(md5[:])
+	encoded := base64.URLEncoding.EncodeToString(md5[:])
 	if len(encoded) > maxLength {
 		return encoded[0:maxLength]
 	} else {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -15,8 +15,15 @@ var _ = Describe("RandomAlphaNum", func() {
 })
 
 var _ = Describe("GetMD5B64", func() {
-	It("returns the Base64 of a string MD5", func() {
+	It("returns the Base64 encoded MD5 hash of the given string", func() {
 		md5b64 := GetMD5B64("ce71b484-d542-40f7-9dd4-5526e38c81ba", 32)
-		Expect(md5b64).To(Equal("Y2U3MWI0ODQtZDU0Mi00MGY3LTlkZDQt"))
+		// Expectation generated with
+		// echo -n ce71b484-d542-40f7-9dd4-5526e38c81ba | openssl dgst -md5 -binary | openssl enc -base64
+		Expect(md5b64).To(Equal("OzUBBVyWFqGmb7pb54mPVQ=="))
+	})
+
+	It("truncates the result when it's longer than the resuested max size", func() {
+		md5b64 := GetMD5B64("ce71b484-d542-40f7-9dd4-5526e38c81ba", 16)
+		Expect(md5b64).To(Equal("OzUBBVyWFqGmb7pb"))
 	})
 })

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -26,4 +26,11 @@ var _ = Describe("GetMD5B64", func() {
 		md5b64 := GetMD5B64("ce71b484-d542-40f7-9dd4-5526e38c81ba", 16)
 		Expect(md5b64).To(Equal("OzUBBVyWFqGmb7pb"))
 	})
+
+	It("Uses the URL safe base64 scheme", func() {
+		md5b64 := GetMD5B64("1123456678", 32)
+		// Expectation generated with
+		// echo -n 1123456678 | openssl dgst -md5 -binary | openssl enc -base64 | tr '+/' '-_'
+		Expect(md5b64).To(Equal("4P7L73_9u3fGZbGG-GDHOw=="))
+	})
 })


### PR DESCRIPTION
# What

Presently, if you know the service GUID for a database instance, you can
determine the master password. This should not be possible as this
password is supposed to be secret.

This adds a configuration variable `master_password_seed` which is added
to the service GUID before hashing. This means that it's no longer
possible to determine the master password from the instance_id alone.

This PR also includes fixes for the `utils.GetMD5B64` function which wasn't using the md5 library correctly.  See the commit message for details.
# How to review

Code review

Test the changes as follows:
## Use docker to build the broker

``` sh
cd /path/to/paas-rds-broker
docker run --rm -t -i -v "$(pwd):/go/src/github.com/alphagov/paas-rds-broker" golang:1.5.3 bash

cd /go/src/github.com/alphagov/paas-rds-broker
export GOPATH=$GOPATH:$(pwd)/Godeps/_workspace
go build
exit
```
## Upload to rds_broker machine

Upload the binary to S3 and make publicly readable

``` sh
aws s3 cp paas-rds-broker s3://${DEPLOY_ENV}-state/paas-rds-broker
aws s3api put-object-acl --bucket ${DEPLOY_ENV}-state --key paas-rds-broker --acl public-read
```

Replace binary on rds_broker machine

``` sh
make dev bosh-cli
bosh ssh rds_broker_z1
sudo -i
monit stop rds-broker
cd /var/vcap/packages/rds-broker/bin
mv paas-rds-broker paas-rds-broker.orig
wget https://s3-eu-west-1.amazonaws.com/${DEPLOY_ENV}-state/paas-rds-broker
chmod +x paas-rds-broker
vi /var/vcap/jobs/rds-broker/config/rds-config.json
# Add `"master_password_seed": "secret",` to the `rds_config` section.
monit start rds-broker
```
## Test
- Create a service instance, and obtain it's UUID (This can be found in the output from `cf curl /v2/service_instances`)
- ssh to the rds_broker VM.
- Install the postgresql client (`apt-get update && apt-get install postgresql-client`)
- Obtain the db hostname, username and database name from the RDS console.
- Generate the expected password: `echo -n "secret<GUID>" | openssl dgst -md5 -binary | openssl enc -base64 | tr '+/' '-_'`
- verify you can connect to the database using these credentials: `psql -h <db_hostname> -U <db_username> <database_name>`
# Who can review

Anyone but @keymon or myself.
