### PR TITLE
[#120831785] Redact passwords in debug logs.

### DIFF
--- a/awsrds/rds_db_instance.go
+++ b/awsrds/rds_db_instance.go
@@ -69,7 +69,10 @@ func (r *RDSDBInstance) Describe(ID string) (DBInstanceDetails, error) {
 
 func (r *RDSDBInstance) Create(ID string, dbInstanceDetails DBInstanceDetails) error {
 	createDBInstanceInput := r.buildCreateDBInstanceInput(ID, dbInstanceDetails)
-	r.logger.Debug("create-db-instance", lager.Data{"input": createDBInstanceInput})
+
+	sanitizedDBInstanceInput := *createDBInstanceInput
+	sanitizedDBInstanceInput.MasterUserPassword = aws.String("REDACTED")
+	r.logger.Debug("create-db-instance", lager.Data{"input": &sanitizedDBInstanceInput})
 
 	createDBInstanceOutput, err := r.rdssvc.CreateDBInstance(createDBInstanceInput)
 	if err != nil {
@@ -95,7 +98,10 @@ func (r *RDSDBInstance) Modify(ID string, dbInstanceDetails DBInstanceDetails, a
 	}
 
 	modifyDBInstanceInput := r.buildModifyDBInstanceInput(ID, dbInstanceDetails, oldDBInstanceDetails, applyImmediately)
-	r.logger.Debug("modify-db-instance", lager.Data{"input": modifyDBInstanceInput})
+
+	sanitizedDBInstanceInput := *modifyDBInstanceInput
+	sanitizedDBInstanceInput.MasterUserPassword = aws.String("REDACTED")
+	r.logger.Debug("modify-db-instance", lager.Data{"input": &sanitizedDBInstanceInput})
 
 	modifyDBInstanceOutput, err := r.rdssvc.ModifyDBInstance(modifyDBInstanceInput)
 	if err != nil {

--- a/sqlengine/postgres_engine.go
+++ b/sqlengine/postgres_engine.go
@@ -21,8 +21,11 @@ func NewPostgresEngine(logger lager.Logger) *PostgresEngine {
 }
 
 func (d *PostgresEngine) Open(address string, port int64, dbname string, username string, password string) error {
-	connectionString := d.connectionString(address, port, dbname, username, password)
-	d.logger.Debug("sql-open", lager.Data{"connection-string": connectionString})
+	var (
+		connectionString          = d.connectionString(address, port, dbname, username, password)
+		sanitizedConnectionString = d.connectionString(address, port, dbname, username, "REDACTED")
+	)
+	d.logger.Debug("sql-open", lager.Data{"connection-string": sanitizedConnectionString})
 
 	db, err := sql.Open("postgres", connectionString)
 	if err != nil {
@@ -93,8 +96,11 @@ func (d *PostgresEngine) DropDB(dbname string) error {
 }
 
 func (d *PostgresEngine) CreateUser(username string, password string) error {
-	createUserStatement := "CREATE USER \"" + username + "\" WITH PASSWORD '" + password + "'"
-	d.logger.Debug("create-user", lager.Data{"statement": createUserStatement})
+	var (
+		createUserStatement          = "CREATE USER \"" + username + "\" WITH PASSWORD '" + password + "'"
+		sanitizedCreateUserStatement = "CREATE USER \"" + username + "\" WITH PASSWORD 'REDACTED'"
+	)
+	d.logger.Debug("create-user", lager.Data{"statement": sanitizedCreateUserStatement})
 
 	if _, err := d.db.Exec(createUserStatement); err != nil {
 		d.logger.Error("sql-error", err)


### PR DESCRIPTION
# What

@combor noticed this will working on the above story.

The bosh-release defaults to DEBUG level logging, which means that both
the master password, and user passwords are currently being exposed in
the logs.

This adds some sanitization to the API call details before logging them
so that these passwords aren't exposed.
# How to review

Code review. Verify that tests pass.

Manually upload a binary compiled from this branch (as described in #5), and verify that the custom acceptance tests still pass, and that no passwords are logged.
# Who can review

Anyone but myself.
