### PR TITLE
[#121133283] Fix Postgres user permission handling

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -4,12 +4,13 @@ A sample configuration can be found at [config-sample.json](https://github.com/a
 
 ## General Configuration
 
-| Option     | Required | Type   | Description
-|:-----------|:--------:|:------ |:-----------
-| log_level  | Y        | String | Broker Log Level (DEBUG, INFO, ERROR, FATAL)
-| username   | Y        | String | Broker Auth Username
-| password   | Y        | String | Broker Auth Password
-| rds_config | Y        | Hash   | [RDS Broker configuration](https://github.com/alphagov/paas-rds-broker/blob/master/CONFIGURATION.md#rds-broker-configuration)
+| Option               | Required | Type   | Description
+|:---------------------|:--------:|:------ |:-----------
+| log_level            | Y        | String | Broker Log Level (DEBUG, INFO, ERROR, FATAL)
+| username             | Y        | String | Broker Auth Username
+| password             | Y        | String | Broker Auth Password
+| state_encryption_key | Y        | String | Key used to encrypt any secrets stored in the database
+| rds_config           | Y        | Hash   | [RDS Broker configuration](https://github.com/alphagov/paas-rds-broker/blob/master/CONFIGURATION.md#rds-broker-configuration)
 
 ## RDS Broker Configuration
 

--- a/README.md
+++ b/README.md
@@ -113,14 +113,6 @@ Update calls support the following optional [arbitrary parameters](https://docs.
 
 (*) Refer to the [Amazon Relational Database Service Documentation](https://aws.amazon.com/documentation/rds/) for more details about how to set these properties
 
-#### Bind
-
-Bind calls support the following optional [arbitrary parameters](https://docs.cloudfoundry.org/devguide/services/application-binding.html#arbitrary-params-binding):
-
-| Option | Type   | Description
-|:-------|:------ |:-----------
-| dbname | String | The name of the Database to bind the application to (it must be provisioned previously)
-
 ## Contributing
 
 In the spirit of [free software](http://www.fsf.org/licensing/essays/free-sw.html), **everyone** is encouraged to help improve this project.

--- a/config-sample.json
+++ b/config-sample.json
@@ -2,6 +2,7 @@
   "log_level": "DEBUG",
   "username": "username",
   "password": "password",
+  "state_encryption_key": "key",
   "rds_config": {
     "region": "us-east-1",
     "db_prefix": "cf",

--- a/config.go
+++ b/config.go
@@ -11,10 +11,11 @@ import (
 )
 
 type Config struct {
-	LogLevel  string           `json:"log_level"`
-	Username  string           `json:"username"`
-	Password  string           `json:"password"`
-	RDSConfig rdsbroker.Config `json:"rds_config"`
+	LogLevel           string           `json:"log_level"`
+	Username           string           `json:"username"`
+	Password           string           `json:"password"`
+	StateEncryptionKey string           `json:"state_encryption_key"`
+	RDSConfig          rdsbroker.Config `json:"rds_config"`
 }
 
 func LoadConfig(configFile string) (config *Config, err error) {
@@ -55,6 +56,10 @@ func (c Config) Validate() error {
 
 	if c.Password == "" {
 		return errors.New("Must provide a non-empty Password")
+	}
+
+	if c.StateEncryptionKey == "" {
+		return errors.New("Must provide a non-empty StateEncryptionKey")
 	}
 
 	if err := c.RDSConfig.Validate(); err != nil {

--- a/config_test.go
+++ b/config_test.go
@@ -14,9 +14,10 @@ var _ = Describe("Config", func() {
 		config Config
 
 		validConfig = Config{
-			LogLevel: "DEBUG",
-			Username: "broker-username",
-			Password: "broker-password",
+			LogLevel:           "DEBUG",
+			Username:           "broker-username",
+			Password:           "broker-password",
+			StateEncryptionKey: "key",
 			RDSConfig: rdsbroker.Config{
 				Region:             "rds-region",
 				DBPrefix:           "cf",
@@ -58,6 +59,14 @@ var _ = Describe("Config", func() {
 			err := config.Validate()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("Must provide a non-empty Password"))
+		})
+
+		It("returns error if StateEncryptionKey is not valid", func() {
+			config.StateEncryptionKey = ""
+
+			err := config.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Must provide a non-empty StateEncryptionKey"))
 		})
 
 		It("returns error if RDS configuration is not valid", func() {

--- a/main.go
+++ b/main.go
@@ -67,7 +67,7 @@ func main() {
 
 	dbInstance := awsrds.NewRDSDBInstance(config.RDSConfig.Region, rdssvc, stssvc, logger)
 
-	sqlProvider := sqlengine.NewProviderService(logger)
+	sqlProvider := sqlengine.NewProviderService(logger, config.StateEncryptionKey)
 
 	serviceBroker := rdsbroker.New(config.RDSConfig, dbInstance, sqlProvider, logger)
 

--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -251,11 +251,7 @@ func (b *RDSBroker) Bind(instanceID, bindingID string, details brokerapi.BindDet
 	dbUsername := b.dbUsername(bindingID)
 	dbPassword := b.dbPassword()
 
-	if err = sqlEngine.CreateUser(dbUsername, dbPassword); err != nil {
-		return bindingResponse, err
-	}
-
-	if err = sqlEngine.GrantPrivileges(dbName, dbUsername); err != nil {
+	if err = sqlEngine.CreateUser(dbUsername, dbPassword, dbName); err != nil {
 		return bindingResponse, err
 	}
 

--- a/rdsbroker/broker_test.go
+++ b/rdsbroker/broker_test.go
@@ -1228,9 +1228,7 @@ var _ = Describe("RDS Broker", func() {
 			Expect(sqlEngine.CreateUserCalled).To(BeTrue())
 			Expect(sqlEngine.CreateUserUsername).To(Equal(dbUsername))
 			Expect(sqlEngine.CreateUserPassword).ToNot(BeEmpty())
-			Expect(sqlEngine.GrantPrivilegesCalled).To(BeTrue())
-			Expect(sqlEngine.GrantPrivilegesDBName).To(Equal("test-db"))
-			Expect(sqlEngine.GrantPrivilegesUsername).To(Equal(dbUsername))
+			Expect(sqlEngine.CreateUserDBName).To(Equal("test-db"))
 			Expect(sqlEngine.CloseCalled).To(BeTrue())
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -1352,19 +1350,6 @@ var _ = Describe("RDS Broker", func() {
 				_, err := rdsBroker.Bind(instanceID, bindingID, bindDetails)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("Failed to create user"))
-				Expect(sqlEngine.CloseCalled).To(BeTrue())
-			})
-		})
-
-		Context("when granting privileges fails", func() {
-			BeforeEach(func() {
-				sqlEngine.GrantPrivilegesError = errors.New("Failed to grant privileges")
-			})
-
-			It("returns the proper error", func() {
-				_, err := rdsBroker.Bind(instanceID, bindingID, bindDetails)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("Failed to grant privileges"))
 				Expect(sqlEngine.CloseCalled).To(BeTrue())
 			})
 		})

--- a/rdsbroker/broker_test.go
+++ b/rdsbroker/broker_test.go
@@ -1197,6 +1197,9 @@ var _ = Describe("RDS Broker", func() {
 				DBName:         "test-db",
 				MasterUsername: "master-username",
 			}
+
+			sqlEngine.CreateUserUsername = dbUsername
+			sqlEngine.CreateUserPassword = "secret"
 		})
 
 		It("returns the proper response", func() {
@@ -1207,7 +1210,7 @@ var _ = Describe("RDS Broker", func() {
 			Expect(credentials.Port).To(Equal(int64(3306)))
 			Expect(credentials.Name).To(Equal("test-db"))
 			Expect(credentials.Username).To(Equal(dbUsername))
-			Expect(credentials.Password).ToNot(BeEmpty())
+			Expect(credentials.Password).To(Equal("secret"))
 			Expect(credentials.URI).To(ContainSubstring("@endpoint-address:3306/test-db?reconnect=true"))
 			Expect(credentials.JDBCURI).To(ContainSubstring("jdbc:fake://endpoint-address:3306/test-db?user=" + dbUsername + "&password="))
 			Expect(err).ToNot(HaveOccurred())
@@ -1226,8 +1229,7 @@ var _ = Describe("RDS Broker", func() {
 			Expect(sqlEngine.OpenUsername).To(Equal("master-username"))
 			Expect(sqlEngine.OpenPassword).ToNot(BeEmpty())
 			Expect(sqlEngine.CreateUserCalled).To(BeTrue())
-			Expect(sqlEngine.CreateUserUsername).To(Equal(dbUsername))
-			Expect(sqlEngine.CreateUserPassword).ToNot(BeEmpty())
+			Expect(sqlEngine.CreateUserBindingID).To(Equal(bindingID))
 			Expect(sqlEngine.CreateUserDBName).To(Equal("test-db"))
 			Expect(sqlEngine.CloseCalled).To(BeTrue())
 			Expect(err).ToNot(HaveOccurred())
@@ -1388,7 +1390,7 @@ var _ = Describe("RDS Broker", func() {
 			Expect(sqlEngine.OpenUsername).To(Equal("master-username"))
 			Expect(sqlEngine.OpenPassword).ToNot(BeEmpty())
 			Expect(sqlEngine.DropUserCalled).To(BeTrue())
-			Expect(sqlEngine.DropUserUsername).To(Equal(dbUsername))
+			Expect(sqlEngine.DropUserBindingID).To(Equal(bindingID))
 			Expect(sqlEngine.CloseCalled).To(BeTrue())
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/rdsbroker/parameters.go
+++ b/rdsbroker/parameters.go
@@ -16,5 +16,6 @@ type UpdateParameters struct {
 }
 
 type BindParameters struct {
-	DBName string `mapstructure:"dbname"`
+	// This is currently empty, but preserved to make it easier to add
+	// bind-time parameters in future.
 }

--- a/sqlengine/crypto.go
+++ b/sqlengine/crypto.go
@@ -1,0 +1,57 @@
+package sqlengine
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"io"
+)
+
+func encryptString(keyStr, plaintext string) (string, error) {
+	cipher, err := buildCipher(keyStr)
+	if err != nil {
+		return "", err
+	}
+	encrypted, err := makeNonce(cipher.NonceSize())
+	if err != nil {
+		return "", err
+	}
+
+	encrypted = cipher.Seal(encrypted, encrypted[:cipher.NonceSize()], []byte(plaintext), nil)
+	return base64.URLEncoding.EncodeToString(encrypted), nil
+}
+
+func decryptString(keyStr, ciphertextStr string) (string, error) {
+	ciphertext, err := base64.URLEncoding.DecodeString(ciphertextStr)
+	if err != nil {
+		return "", err
+	}
+
+	cipher, err := buildCipher(keyStr)
+	if err != nil {
+		return "", err
+	}
+
+	decrypted, err := cipher.Open(nil, ciphertext[:cipher.NonceSize()], ciphertext[cipher.NonceSize():], nil)
+	if err != nil {
+		return "", err
+	}
+	return string(decrypted), nil
+}
+
+func buildCipher(keyStr string) (cipher.AEAD, error) {
+	key := sha256.Sum256([]byte(keyStr))
+	block, err := aes.NewCipher(key[:])
+	if err != nil {
+		return nil, err
+	}
+	return cipher.NewGCM(block)
+}
+
+func makeNonce(size int) ([]byte, error) {
+	nonce := make([]byte, size)
+	_, err := io.ReadFull(rand.Reader, nonce)
+	return nonce, err
+}

--- a/sqlengine/crypto_test.go
+++ b/sqlengine/crypto_test.go
@@ -1,0 +1,44 @@
+package sqlengine
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("crypto functions", func() {
+	const (
+		key  = "some secret key"
+		text = "a secret message"
+	)
+
+	It("can encrypt and decrypt a value", func() {
+		encrypted, err := encryptString(key, text)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(encrypted).NotTo(Equal(text))
+
+		decrypted, err := decryptString(key, encrypted)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(decrypted).To(Equal(text))
+	})
+
+	It("generates different ciphertext each time", func() {
+		// It's important that symmetric encryption uses an IV or nonce so that
+		// it's not possible to obtain information about the key by comparing 2
+		// or more different ciphertexts.
+		encrypted1, err := encryptString(key, text)
+		Expect(err).NotTo(HaveOccurred())
+
+		encrypted2, err := encryptString(key, text)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(encrypted2).NotTo(Equal(encrypted1))
+	})
+
+	It("isn't possible to decrypt with the wrong key", func() {
+		encrypted, err := encryptString(key, text)
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = decryptString("not the key", encrypted)
+		Expect(err).To(MatchError(ContainSubstring("message authentication failed")))
+	})
+})

--- a/sqlengine/fakes/fake_sql_engine.go
+++ b/sqlengine/fakes/fake_sql_engine.go
@@ -15,18 +15,6 @@ type FakeSQLEngine struct {
 
 	CloseCalled bool
 
-	ExistsDBCalled bool
-	ExistsDBDBName string
-	ExistsDBError  error
-
-	CreateDBCalled bool
-	CreateDBDBName string
-	CreateDBError  error
-
-	DropDBCalled bool
-	DropDBDBName string
-	DropDBError  error
-
 	CreateUserCalled   bool
 	CreateUserUsername string
 	CreateUserPassword string
@@ -36,19 +24,10 @@ type FakeSQLEngine struct {
 	DropUserUsername string
 	DropUserError    error
 
-	PrivilegesCalled     bool
-	PrivilegesPrivileges map[string][]string
-	PrivilegesError      error
-
 	GrantPrivilegesCalled   bool
 	GrantPrivilegesDBName   string
 	GrantPrivilegesUsername string
 	GrantPrivilegesError    error
-
-	RevokePrivilegesCalled   bool
-	RevokePrivilegesDBName   string
-	RevokePrivilegesUsername string
-	RevokePrivilegesError    error
 }
 
 func (f *FakeSQLEngine) Open(address string, port int64, dbname string, username string, password string) error {
@@ -66,27 +45,6 @@ func (f *FakeSQLEngine) Close() {
 	f.CloseCalled = true
 }
 
-func (f *FakeSQLEngine) ExistsDB(dbname string) (bool, error) {
-	f.ExistsDBCalled = true
-	f.ExistsDBDBName = dbname
-
-	return true, f.ExistsDBError
-}
-
-func (f *FakeSQLEngine) CreateDB(dbname string) error {
-	f.CreateDBCalled = true
-	f.CreateDBDBName = dbname
-
-	return f.CreateDBError
-}
-
-func (f *FakeSQLEngine) DropDB(dbname string) error {
-	f.DropDBCalled = true
-	f.DropDBDBName = dbname
-
-	return f.DropDBError
-}
-
 func (f *FakeSQLEngine) CreateUser(username string, password string) error {
 	f.CreateUserCalled = true
 	f.CreateUserUsername = username
@@ -102,26 +60,12 @@ func (f *FakeSQLEngine) DropUser(username string) error {
 	return f.DropUserError
 }
 
-func (f *FakeSQLEngine) Privileges() (map[string][]string, error) {
-	f.PrivilegesCalled = true
-
-	return f.PrivilegesPrivileges, f.PrivilegesError
-}
-
 func (f *FakeSQLEngine) GrantPrivileges(dbname string, username string) error {
 	f.GrantPrivilegesCalled = true
 	f.GrantPrivilegesDBName = dbname
 	f.GrantPrivilegesUsername = username
 
 	return f.GrantPrivilegesError
-}
-
-func (f *FakeSQLEngine) RevokePrivileges(dbname string, username string) error {
-	f.RevokePrivilegesCalled = true
-	f.RevokePrivilegesDBName = dbname
-	f.RevokePrivilegesUsername = username
-
-	return f.RevokePrivilegesError
 }
 
 func (f *FakeSQLEngine) URI(address string, port int64, dbname string, username string, password string) string {

--- a/sqlengine/fakes/fake_sql_engine.go
+++ b/sqlengine/fakes/fake_sql_engine.go
@@ -15,15 +15,17 @@ type FakeSQLEngine struct {
 
 	CloseCalled bool
 
-	CreateUserCalled   bool
+	CreateUserCalled    bool
+	CreateUserBindingID string
+	CreateUserDBName    string
+	// returns
 	CreateUserUsername string
 	CreateUserPassword string
-	CreateUserDBName   string
 	CreateUserError    error
 
-	DropUserCalled   bool
-	DropUserUsername string
-	DropUserError    error
+	DropUserCalled    bool
+	DropUserBindingID string
+	DropUserError     error
 }
 
 func (f *FakeSQLEngine) Open(address string, port int64, dbname string, username string, password string) error {
@@ -41,18 +43,17 @@ func (f *FakeSQLEngine) Close() {
 	f.CloseCalled = true
 }
 
-func (f *FakeSQLEngine) CreateUser(username, password, dbname string) error {
+func (f *FakeSQLEngine) CreateUser(bindingID, dbname string) (username, password string, err error) {
 	f.CreateUserCalled = true
-	f.CreateUserUsername = username
+	f.CreateUserBindingID = bindingID
 	f.CreateUserDBName = dbname
-	f.CreateUserPassword = password
 
-	return f.CreateUserError
+	return f.CreateUserUsername, f.CreateUserPassword, f.CreateUserError
 }
 
-func (f *FakeSQLEngine) DropUser(username string) error {
+func (f *FakeSQLEngine) DropUser(bindingID string) error {
 	f.DropUserCalled = true
-	f.DropUserUsername = username
+	f.DropUserBindingID = bindingID
 
 	return f.DropUserError
 }

--- a/sqlengine/fakes/fake_sql_engine.go
+++ b/sqlengine/fakes/fake_sql_engine.go
@@ -18,16 +18,12 @@ type FakeSQLEngine struct {
 	CreateUserCalled   bool
 	CreateUserUsername string
 	CreateUserPassword string
+	CreateUserDBName   string
 	CreateUserError    error
 
 	DropUserCalled   bool
 	DropUserUsername string
 	DropUserError    error
-
-	GrantPrivilegesCalled   bool
-	GrantPrivilegesDBName   string
-	GrantPrivilegesUsername string
-	GrantPrivilegesError    error
 }
 
 func (f *FakeSQLEngine) Open(address string, port int64, dbname string, username string, password string) error {
@@ -45,9 +41,10 @@ func (f *FakeSQLEngine) Close() {
 	f.CloseCalled = true
 }
 
-func (f *FakeSQLEngine) CreateUser(username string, password string) error {
+func (f *FakeSQLEngine) CreateUser(username, password, dbname string) error {
 	f.CreateUserCalled = true
 	f.CreateUserUsername = username
+	f.CreateUserDBName = dbname
 	f.CreateUserPassword = password
 
 	return f.CreateUserError
@@ -58,14 +55,6 @@ func (f *FakeSQLEngine) DropUser(username string) error {
 	f.DropUserUsername = username
 
 	return f.DropUserError
-}
-
-func (f *FakeSQLEngine) GrantPrivileges(dbname string, username string) error {
-	f.GrantPrivilegesCalled = true
-	f.GrantPrivilegesDBName = dbname
-	f.GrantPrivilegesUsername = username
-
-	return f.GrantPrivilegesError
 }
 
 func (f *FakeSQLEngine) URI(address string, port int64, dbname string, username string, password string) string {

--- a/sqlengine/mysql_engine.go
+++ b/sqlengine/mysql_engine.go
@@ -40,54 +40,6 @@ func (d *MySQLEngine) Close() {
 	}
 }
 
-func (d *MySQLEngine) ExistsDB(dbname string) (bool, error) {
-	selectDatabaseStatement := "SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = '" + dbname + "'"
-	d.logger.Debug("database-exists", lager.Data{"statement": selectDatabaseStatement})
-
-	var dummy string
-	err := d.db.QueryRow(selectDatabaseStatement).Scan(&dummy)
-	switch {
-	case err == sql.ErrNoRows:
-		return false, nil
-	case err != nil:
-		return false, err
-	}
-
-	return true, nil
-}
-
-func (d *MySQLEngine) CreateDB(dbname string) error {
-	ok, err := d.ExistsDB(dbname)
-	if err != nil {
-		return err
-	}
-	if ok {
-		return nil
-	}
-
-	createDBStatement := "CREATE DATABASE IF NOT EXISTS " + dbname
-	d.logger.Debug("create-database", lager.Data{"statement": createDBStatement})
-
-	if _, err := d.db.Exec(createDBStatement); err != nil {
-		d.logger.Error("sql-error", err)
-		return err
-	}
-
-	return nil
-}
-
-func (d *MySQLEngine) DropDB(dbname string) error {
-	dropDBStatement := "DROP DATABASE IF EXISTS " + dbname
-	d.logger.Debug("drop-database", lager.Data{"statement": dropDBStatement})
-
-	if _, err := d.db.Exec(dropDBStatement); err != nil {
-		d.logger.Error("sql-error", err)
-		return err
-	}
-
-	return nil
-}
-
 func (d *MySQLEngine) CreateUser(username string, password string) error {
 	createUserStatement := "CREATE USER '" + username + "' IDENTIFIED BY '" + password + "'"
 	d.logger.Debug("create-user", lager.Data{"statement": createUserStatement})
@@ -112,59 +64,11 @@ func (d *MySQLEngine) DropUser(username string) error {
 	return nil
 }
 
-func (d *MySQLEngine) Privileges() (map[string][]string, error) {
-	privileges := make(map[string][]string)
-
-	selectPrivilegesStatement := "SELECT db, user FROM mysql.db"
-	d.logger.Debug("database-privileges", lager.Data{"statement": selectPrivilegesStatement})
-
-	rows, err := d.db.Query(selectPrivilegesStatement)
-	if err != nil {
-		d.logger.Error("sql-error", err)
-		return privileges, err
-	}
-	defer rows.Close()
-
-	var dbname, username string
-	for rows.Next() {
-		err := rows.Scan(&dbname, &username)
-		if err != nil {
-			d.logger.Error("sql-error", err)
-			return privileges, err
-		}
-		if _, ok := privileges[dbname]; !ok {
-			privileges[dbname] = []string{}
-		}
-		privileges[dbname] = append(privileges[dbname], username)
-	}
-	err = rows.Err()
-	if err != nil {
-		d.logger.Error("sql-error", err)
-		return privileges, err
-	}
-
-	d.logger.Debug("database-privileges", lager.Data{"output": privileges})
-
-	return privileges, nil
-}
-
 func (d *MySQLEngine) GrantPrivileges(dbname string, username string) error {
 	grantPrivilegesStatement := "GRANT ALL PRIVILEGES ON " + dbname + ".* TO '" + username + "'@'%'"
 	d.logger.Debug("grant-privileges", lager.Data{"statement": grantPrivilegesStatement})
 
 	if _, err := d.db.Exec(grantPrivilegesStatement); err != nil {
-		d.logger.Error("sql-error", err)
-		return err
-	}
-
-	return nil
-}
-
-func (d *MySQLEngine) RevokePrivileges(dbname string, username string) error {
-	revokePrivilegesStatement := "REVOKE ALL PRIVILEGES ON " + dbname + ".* from '" + username + "'@'%'"
-	d.logger.Debug("revoke-privileges", lager.Data{"statement": revokePrivilegesStatement})
-
-	if _, err := d.db.Exec(revokePrivilegesStatement); err != nil {
 		d.logger.Error("sql-error", err)
 		return err
 	}

--- a/sqlengine/postgres_engine.go
+++ b/sqlengine/postgres_engine.go
@@ -56,58 +56,6 @@ func (d *PostgresEngine) Close() {
 	}
 }
 
-func (d *PostgresEngine) ExistsDB(dbname string) (bool, error) {
-	selectDatabaseStatement := "SELECT datname FROM pg_database WHERE datname='" + dbname + "'"
-	d.logger.Debug("database-exists", lager.Data{"statement": selectDatabaseStatement})
-
-	var dummy string
-	err := d.db.QueryRow(selectDatabaseStatement).Scan(&dummy)
-	switch {
-	case err == sql.ErrNoRows:
-		return false, nil
-	case err != nil:
-		return false, err
-	}
-
-	return true, nil
-}
-
-func (d *PostgresEngine) CreateDB(dbname string) error {
-	ok, err := d.ExistsDB(dbname)
-	if err != nil {
-		return err
-	}
-	if ok {
-		return nil
-	}
-
-	createDBStatement := "CREATE DATABASE \"" + dbname + "\""
-	d.logger.Debug("create-database", lager.Data{"statement": createDBStatement})
-
-	if _, err := d.db.Exec(createDBStatement); err != nil {
-		d.logger.Error("sql-error", err)
-		return err
-	}
-
-	return nil
-}
-
-func (d *PostgresEngine) DropDB(dbname string) error {
-	if err := d.dropConnections(dbname); err != nil {
-		return err
-	}
-
-	dropDBStatement := "DROP DATABASE IF EXISTS \"" + dbname + "\""
-	d.logger.Debug("drop-database", lager.Data{"statement": dropDBStatement})
-
-	if _, err := d.db.Exec(dropDBStatement); err != nil {
-		d.logger.Error("sql-error", err)
-		return err
-	}
-
-	return nil
-}
-
 func (d *PostgresEngine) CreateUser(username string, password string) error {
 	var (
 		createUserStatement          = "CREATE USER \"" + username + "\" WITH PASSWORD '" + password + "'"
@@ -129,59 +77,11 @@ func (d *PostgresEngine) DropUser(username string) error {
 	return nil
 }
 
-func (d *PostgresEngine) Privileges() (map[string][]string, error) {
-	privileges := make(map[string][]string)
-
-	selectPrivilegesStatement := "SELECT datname, usename FROM pg_database d, pg_user u WHERE usecreatedb = false AND (SELECT has_database_privilege(u.usename, d.datname, 'create'))"
-	d.logger.Debug("database-privileges", lager.Data{"statement": selectPrivilegesStatement})
-
-	rows, err := d.db.Query(selectPrivilegesStatement)
-	if err != nil {
-		d.logger.Error("sql-error", err)
-		return privileges, err
-	}
-	defer rows.Close()
-
-	var dbname, username string
-	for rows.Next() {
-		err := rows.Scan(&dbname, &username)
-		if err != nil {
-			d.logger.Error("sql-error", err)
-			return privileges, err
-		}
-		if _, ok := privileges[dbname]; !ok {
-			privileges[dbname] = []string{}
-		}
-		privileges[dbname] = append(privileges[dbname], username)
-	}
-	err = rows.Err()
-	if err != nil {
-		d.logger.Error("sql-error", err)
-		return privileges, err
-	}
-
-	d.logger.Debug("database-privileges", lager.Data{"output": privileges})
-
-	return privileges, nil
-}
-
 func (d *PostgresEngine) GrantPrivileges(dbname string, username string) error {
 	grantPrivilegesStatement := "GRANT ALL PRIVILEGES ON DATABASE \"" + dbname + "\" TO \"" + username + "\""
 	d.logger.Debug("grant-privileges", lager.Data{"statement": grantPrivilegesStatement})
 
 	if _, err := d.db.Exec(grantPrivilegesStatement); err != nil {
-		d.logger.Error("sql-error", err)
-		return err
-	}
-
-	return nil
-}
-
-func (d *PostgresEngine) RevokePrivileges(dbname string, username string) error {
-	revokePrivilegesStatement := "REVOKE ALL PRIVILEGES ON DATABASE \"" + dbname + "\" FROM \"" + username + "\""
-	d.logger.Debug("revoke-privileges", lager.Data{"statement": revokePrivilegesStatement})
-
-	if _, err := d.db.Exec(revokePrivilegesStatement); err != nil {
 		d.logger.Error("sql-error", err)
 		return err
 	}
@@ -195,18 +95,6 @@ func (d *PostgresEngine) URI(address string, port int64, dbname string, username
 
 func (d *PostgresEngine) JDBCURI(address string, port int64, dbname string, username string, password string) string {
 	return fmt.Sprintf("jdbc:postgresql://%s:%d/%s?user=%s&password=%s", address, port, dbname, username, password)
-}
-
-func (d *PostgresEngine) dropConnections(dbname string) error {
-	dropDBConnectionsStatement := "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '" + dbname + "' AND pid <> pg_backend_pid()"
-	d.logger.Debug("drop-connections", lager.Data{"statement": dropDBConnectionsStatement})
-
-	if _, err := d.db.Exec(dropDBConnectionsStatement); err != nil {
-		d.logger.Error("sql-error", err)
-		return err
-	}
-
-	return nil
 }
 
 func (d *PostgresEngine) connectionString(address string, port int64, dbname string, username string, password string) string {

--- a/sqlengine/postgres_engine.go
+++ b/sqlengine/postgres_engine.go
@@ -22,8 +22,8 @@ func NewPostgresEngine(logger lager.Logger) *PostgresEngine {
 
 func (d *PostgresEngine) Open(address string, port int64, dbname string, username string, password string) error {
 	var (
-		connectionString          = d.connectionString(address, port, dbname, username, password)
-		sanitizedConnectionString = d.connectionString(address, port, dbname, username, "REDACTED")
+		connectionString          = d.URI(address, port, dbname, username, password)
+		sanitizedConnectionString = d.URI(address, port, dbname, username, "REDACTED")
 	)
 	d.logger.Debug("sql-open", lager.Data{"connection-string": sanitizedConnectionString})
 
@@ -95,8 +95,4 @@ func (d *PostgresEngine) URI(address string, port int64, dbname string, username
 
 func (d *PostgresEngine) JDBCURI(address string, port int64, dbname string, username string, password string) string {
 	return fmt.Sprintf("jdbc:postgresql://%s:%d/%s?user=%s&password=%s", address, port, dbname, username, password)
-}
-
-func (d *PostgresEngine) connectionString(address string, port int64, dbname string, username string, password string) string {
-	return fmt.Sprintf("host=%s port=%d dbname=%s user='%s' password='%s'", address, port, dbname, username, password)
 }

--- a/sqlengine/postgres_engine.go
+++ b/sqlengine/postgres_engine.go
@@ -56,7 +56,7 @@ func (d *PostgresEngine) Close() {
 	}
 }
 
-func (d *PostgresEngine) CreateUser(username string, password string) error {
+func (d *PostgresEngine) CreateUser(username, password, dbname string) error {
 	var (
 		createUserStatement          = "CREATE USER \"" + username + "\" WITH PASSWORD '" + password + "'"
 		sanitizedCreateUserStatement = "CREATE USER \"" + username + "\" WITH PASSWORD 'REDACTED'"
@@ -68,16 +68,6 @@ func (d *PostgresEngine) CreateUser(username string, password string) error {
 		return err
 	}
 
-	return nil
-}
-
-func (d *PostgresEngine) DropUser(username string) error {
-	// For PostgreSQL we don't drop the user because it might still be owner of some objects
-
-	return nil
-}
-
-func (d *PostgresEngine) GrantPrivileges(dbname string, username string) error {
 	grantPrivilegesStatement := "GRANT ALL PRIVILEGES ON DATABASE \"" + dbname + "\" TO \"" + username + "\""
 	d.logger.Debug("grant-privileges", lager.Data{"statement": grantPrivilegesStatement})
 
@@ -85,6 +75,12 @@ func (d *PostgresEngine) GrantPrivileges(dbname string, username string) error {
 		d.logger.Error("sql-error", err)
 		return err
 	}
+
+	return nil
+}
+
+func (d *PostgresEngine) DropUser(username string) error {
+	// For PostgreSQL we don't drop the user because it might still be owner of some objects
 
 	return nil
 }

--- a/sqlengine/postgres_engine.go
+++ b/sqlengine/postgres_engine.go
@@ -10,17 +10,19 @@ import (
 )
 
 type PostgresEngine struct {
-	logger   lager.Logger
-	db       *sql.DB
-	address  string
-	port     int64
-	username string
-	password string
+	logger             lager.Logger
+	stateEncryptionKey string
+	db                 *sql.DB
+	address            string
+	port               int64
+	username           string
+	password           string
 }
 
-func NewPostgresEngine(logger lager.Logger) *PostgresEngine {
+func NewPostgresEngine(logger lager.Logger, stateEncryptionKey string) *PostgresEngine {
 	return &PostgresEngine{
-		logger: logger.Session("postgres-engine"),
+		logger:             logger.Session("postgres-engine"),
+		stateEncryptionKey: stateEncryptionKey,
 	}
 }
 
@@ -62,7 +64,7 @@ func (d *PostgresEngine) Close() {
 }
 
 func (d *PostgresEngine) CreateUser(bindingID, dbname string) (username, password string, err error) {
-	stateDB, err := d.openStateDB(d.logger)
+	stateDB, err := d.openStateDB(d.logger, d.stateEncryptionKey)
 	if err != nil {
 		return "", "", err
 	}

--- a/sqlengine/postgres_engine_state.go
+++ b/sqlengine/postgres_engine_state.go
@@ -1,0 +1,107 @@
+package sqlengine
+
+import (
+	"database/sql"
+
+	"github.com/lib/pq"
+	"github.com/pivotal-golang/lager"
+)
+
+const stateDBName = "broker_state"
+
+// passwordStorageVersion represents the current method we are using to store
+// passwords. If the way we store or encrypt passwords ever changes, this field
+// (which is stored in the database) will allow us to migrate more easily.
+const passwordStorageVersion = "1.0"
+
+func (d *PostgresEngine) openStateDB(logger lager.Logger) (*postgresEngineState, error) {
+	logger = logger.Session("postgres-engine-state")
+
+	statement := "CREATE DATABASE " + stateDBName
+	logger.Debug("create-database", lager.Data{"statement": statement})
+	_, err := d.db.Exec(statement)
+	if err != nil {
+		// 42P04 means duplicate database - https://www.postgresql.org/docs/9.5/static/errcodes-appendix.html
+		if pqErr, ok := err.(*pq.Error); ok && pqErr.Code == "42P04" {
+			// Database already exists. Carry on.
+		} else {
+			logger.Error("create-database.sql-error", err)
+			return nil, err
+		}
+	} else {
+		// No error, so the database has just been created
+		revokePrivilegesStatement := "REVOKE ALL PRIVILEGES ON DATABASE " + stateDBName + " FROM PUBLIC"
+		logger.Debug("revoke-privileges", lager.Data{"statement": revokePrivilegesStatement})
+		if _, err := d.db.Exec(revokePrivilegesStatement); err != nil {
+			logger.Error("revoke-privileges.sql-error", err)
+			return nil, err
+		}
+	}
+
+	var (
+		stateDBURL          = d.URI(d.address, d.port, stateDBName, d.username, d.password)
+		sanitisedStateDBURL = d.URI(d.address, d.port, stateDBName, d.username, "REDACTED")
+	)
+	logger.Debug("db-open", lager.Data{"connection-string": sanitisedStateDBURL})
+	db, err := sql.Open("postgres", stateDBURL)
+	if err != nil {
+		logger.Error("db-open.sql-error", err)
+		return nil, err
+	}
+
+	s := &postgresEngineState{
+		DB:     db,
+		logger: logger,
+	}
+
+	err = s.initSchema()
+	if err != nil {
+		s.Close()
+		return nil, err
+	}
+
+	return s, nil
+}
+
+type postgresEngineState struct {
+	*sql.DB
+	logger lager.Logger
+}
+
+func (s *postgresEngineState) initSchema() error {
+	statement := "CREATE TABLE IF NOT EXISTS role (username varchar(128) NOT NULL, password varchar(128) NOT NULL, password_storage_version varchar(10), PRIMARY KEY(username))"
+	s.logger.Debug("create-table", lager.Data{"statement": statement})
+	_, err := s.Exec(statement)
+	if err != nil {
+		s.logger.Error("create-table.sql-error", err)
+		return err
+	}
+	return nil
+}
+
+func (s *postgresEngineState) fetchUserPassword(username string) (password string, ok bool, err error) {
+	statement := "SELECT password FROM role WHERE username = $1"
+	s.logger.Debug("fetch-user", lager.Data{"statement": statement, "params": []string{username}})
+	err = s.QueryRow(statement, username).Scan(&password)
+	if err == sql.ErrNoRows {
+		return "", false, nil
+	} else if err != nil {
+		s.logger.Error("fetch-user.sql-error", err)
+		return "", false, err
+	}
+	return password, true, nil
+}
+
+func (s *postgresEngineState) storeUser(username, password string) error {
+	statement := "INSERT INTO role (username, password, password_storage_version) VALUES($1, $2, $3)"
+	s.logger.Debug("insert-user", lager.Data{
+		"statement": statement,
+		"params":    []string{username, "REDACTED", passwordStorageVersion},
+	})
+	_, err := s.Exec(statement, username, password, passwordStorageVersion)
+	if err != nil {
+		s.logger.Error("insert-user.sql-error", err)
+		return err
+	}
+	return nil
+}

--- a/sqlengine/provider_service.go
+++ b/sqlengine/provider_service.go
@@ -8,11 +8,15 @@ import (
 )
 
 type ProviderService struct {
-	logger lager.Logger
+	logger             lager.Logger
+	stateEncryptionKey string
 }
 
-func NewProviderService(logger lager.Logger) *ProviderService {
-	return &ProviderService{logger: logger}
+func NewProviderService(logger lager.Logger, stateEncryptionKey string) *ProviderService {
+	return &ProviderService{
+		logger:             logger,
+		stateEncryptionKey: stateEncryptionKey,
+	}
 }
 
 func (p *ProviderService) GetSQLEngine(engine string) (SQLEngine, error) {
@@ -20,7 +24,7 @@ func (p *ProviderService) GetSQLEngine(engine string) (SQLEngine, error) {
 	case "mariadb", "mysql":
 		return NewMySQLEngine(p.logger), nil
 	case "postgres", "postgresql":
-		return NewPostgresEngine(p.logger), nil
+		return NewPostgresEngine(p.logger, p.stateEncryptionKey), nil
 	}
 
 	return nil, fmt.Errorf("SQL Engine '%s' not supported", engine)

--- a/sqlengine/provider_service_test.go
+++ b/sqlengine/provider_service_test.go
@@ -17,7 +17,7 @@ var _ = Describe("Provider Service", func() {
 
 	BeforeEach(func() {
 		logger = lager.NewLogger("provider_service_test")
-		sqlProvider = NewProviderService(logger)
+		sqlProvider = NewProviderService(logger, "encryption key")
 	})
 
 	Describe("GetSQLEngine", func() {

--- a/sqlengine/sql_engine.go
+++ b/sqlengine/sql_engine.go
@@ -7,14 +7,9 @@ import (
 type SQLEngine interface {
 	Open(address string, port int64, dbname string, username string, password string) error
 	Close()
-	ExistsDB(dbname string) (bool, error)
-	CreateDB(dbname string) error
-	DropDB(dbname string) error
 	CreateUser(username string, password string) error
 	DropUser(username string) error
-	Privileges() (map[string][]string, error)
 	GrantPrivileges(dbname string, username string) error
-	RevokePrivileges(dbname string, username string) error
 	URI(address string, port int64, dbname string, username string, password string) string
 	JDBCURI(address string, port int64, dbname string, username string, password string) string
 }

--- a/sqlengine/sql_engine.go
+++ b/sqlengine/sql_engine.go
@@ -7,9 +7,8 @@ import (
 type SQLEngine interface {
 	Open(address string, port int64, dbname string, username string, password string) error
 	Close()
-	CreateUser(username string, password string) error
+	CreateUser(username, password, dbname string) error
 	DropUser(username string) error
-	GrantPrivileges(dbname string, username string) error
 	URI(address string, port int64, dbname string, username string, password string) string
 	JDBCURI(address string, port int64, dbname string, username string, password string) string
 }

--- a/sqlengine/sql_engine.go
+++ b/sqlengine/sql_engine.go
@@ -2,15 +2,31 @@ package sqlengine
 
 import (
 	"errors"
+	"strings"
+
+	"github.com/alphagov/paas-rds-broker/utils"
+)
+
+const (
+	usernameLength = 16
+	passwordLength = 32
 )
 
 type SQLEngine interface {
 	Open(address string, port int64, dbname string, username string, password string) error
 	Close()
-	CreateUser(username, password, dbname string) error
-	DropUser(username string) error
+	CreateUser(bindingID, dbname string) (string, string, error)
+	DropUser(bindingID string) error
 	URI(address string, port int64, dbname string, username string, password string) string
 	JDBCURI(address string, port int64, dbname string, username string, password string) string
 }
 
 var LoginFailedError = errors.New("Login failed")
+
+func generateUsername(seed string) string {
+	return "u" + strings.Replace(utils.GetMD5B64(seed, usernameLength-1), "-", "_", -1)
+}
+
+func generatePassword() string {
+	return utils.RandomAlphaNum(passwordLength)
+}


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/121133283
## What

This fixes issues with how permissions were being setup for Postgres instances.

Due to how Postgres' permissions model works, we need to re-use the same user for all binds that need access to make schema-level changes (at present, that's all binds). To achieve this, we now need to persist the password to a database on the RDS instance so that it can be returned from bind calls. This therefore adds an encryption key param so that these passwords can be encrypted in the DB.
## How to review

Review as part of the paas-cf PR - https://github.com/alphagov/paas-cf/pull/323
## Who can review

Anyone but @HenryTK, @Jonty, @timmow or myself.
