### PR TITLE
[#118909613] Add healthcheck endpoint

### DIFF
--- a/main.go
+++ b/main.go
@@ -58,6 +58,9 @@ func buildHTTPHandler(serviceBroker *rdsbroker.RDSBroker, logger lager.Logger, c
 	brokerAPI := brokerapi.New(serviceBroker, logger, credentials)
 	mux := http.NewServeMux()
 	mux.Handle("/", brokerAPI)
+	mux.HandleFunc("/healthcheck", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
 	return mux
 }
 

--- a/main.go
+++ b/main.go
@@ -49,6 +49,18 @@ func buildLogger(logLevel string) lager.Logger {
 	return logger
 }
 
+func buildHTTPHandler(serviceBroker *rdsbroker.RDSBroker, logger lager.Logger, config *Config) http.Handler {
+	credentials := brokerapi.BrokerCredentials{
+		Username: config.Username,
+		Password: config.Password,
+	}
+
+	brokerAPI := brokerapi.New(serviceBroker, logger, credentials)
+	mux := http.NewServeMux()
+	mux.Handle("/", brokerAPI)
+	return mux
+}
+
 func main() {
 	flag.Parse()
 
@@ -73,14 +85,8 @@ func main() {
 
 	go serviceBroker.CheckAndRotateCredentials()
 
-	credentials := brokerapi.BrokerCredentials{
-		Username: config.Username,
-		Password: config.Password,
-	}
-
-	brokerAPI := brokerapi.New(serviceBroker, logger, credentials)
-	http.Handle("/", brokerAPI)
+	server := buildHTTPHandler(serviceBroker, logger, config)
 
 	fmt.Println("RDS Service Broker started on port " + port + "...")
-	http.ListenAndServe(":"+port, nil)
+	http.ListenAndServe(":"+port, server)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/alphagov/paas-rds-broker/rdsbroker"
+	"github.com/pivotal-golang/lager"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Main", func() {
+
+	Describe("constructing the top-level HTTP handler", func() {
+
+		It("has a healthcheck endpoint that returns 200", func() {
+			handler := buildHTTPHandler(
+				&rdsbroker.RDSBroker{},
+				lager.NewLogger("main.test"),
+				&Config{},
+			)
+			req, err := http.NewRequest("GET", "http://example.com/healthcheck", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(200))
+		})
+	})
+})


### PR DESCRIPTION
# What

Add a simple `/healthcheck` endpoint, which can be used by ELBs to
check that the broker is running. We have decided not to do any more
complex internal health checks at this time.
# How to test

Build the rds-broker in a docker container and verify that it responds on the healthcheck endpoint without any authentication:

``` sh
cd /path/to/paas-rds-broker
docker run --rm -t -i -v "$(pwd):/go/src/github.com/alphagov/paas-rds-broker" -p 3000:3000 golang:1.5.3 bash

cd /go/src/github.com/alphagov/paas-rds-broker
export GOPATH=$GOPATH:$(pwd)/Godeps/_workspace
go build
cat > config.json <<EOT
{
  "log_level": "DEBUG",
  "username": "username",
  "password": "password",
  "state_encryption_key": "key",
  "rds_config": {
    "region": "us-east-1",
    "db_prefix": "cf",
    "master_password_seed": "seed",
    "broker_name": "name",
    "catalog": { }
  }
}
EOT
./paas-rds-broker -port 3000 -config ./config.json
```

Use curl from the host to hit the healthcheck endpoint:

``` sh
curl -v http://localhost:3000/healthcheck
# OR if using docker-machine:
curl -v http://$(docker-machine ip default):3000/healthcheck
```

Verify you get a 200 response.
# Who can review

Anyone but @mtekel, @HenryTK or myself.
