### PR TITLE
[#124755971] Fix master password reset

### DIFF
--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -390,7 +390,7 @@ func (b *RDSBroker) dbInstanceIdentifier(instanceID string) string {
 }
 
 func (b *RDSBroker) dbInstanceIdentifierToServiceInstanceID(serviceInstanceID string) string {
-	return strings.TrimLeft(serviceInstanceID, b.dbPrefix+"-")
+	return strings.TrimPrefix(serviceInstanceID, strings.Replace(b.dbPrefix, "_", "-", -1)+"-")
 }
 
 func (b *RDSBroker) masterUsername() string {

--- a/rdsbroker/broker_unit_test.go
+++ b/rdsbroker/broker_unit_test.go
@@ -43,5 +43,10 @@ var _ = Describe("RDS Broker internals", func() {
 			actual := broker.dbInstanceIdentifierToServiceInstanceID("with-dash-underscore-123")
 			Expect(actual).To(Equal("123"))
 		})
+
+		It("doesn't strip characters in the ID that are included in the prefix", func() {
+			actual := broker.dbInstanceIdentifierToServiceInstanceID("cf-fc051869-696b-4031-a290-8f45588f308c")
+			Expect(actual).To(Equal("fc051869-696b-4031-a290-8f45588f308c"))
+		})
 	})
 })

--- a/rdsbroker/broker_unit_test.go
+++ b/rdsbroker/broker_unit_test.go
@@ -1,0 +1,47 @@
+package rdsbroker
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("RDS Broker internals", func() {
+	var (
+		broker *RDSBroker
+	)
+
+	BeforeEach(func() {
+		broker = &RDSBroker{
+			dbPrefix: "cf",
+		}
+	})
+
+	Describe("dbInstanceIdentifier", func() {
+		It("combines the dbPrefix with the instanceID", func() {
+			Expect(broker.dbInstanceIdentifier("a8051869-696b-4031-a290-8f45588f308c")).To(Equal("cf-a8051869-696b-4031-a290-8f45588f308c"))
+		})
+
+		It("replaces '_'s in the instanceID with '-'s", func() {
+			Expect(broker.dbInstanceIdentifier("with-dash_underscore")).To(Equal("cf-with-dash-underscore"))
+		})
+
+		It("replaces '_'s in the dbPrefix with '-'s", func() {
+			broker.dbPrefix = "with-dash_underscore"
+			Expect(broker.dbInstanceIdentifier("123")).To(Equal("with-dash-underscore-123"))
+		})
+	})
+
+	Describe("dbInstanceIdentifierToServiceInstanceID", func() {
+
+		It("strips the dbPrefix off", func() {
+			actual := broker.dbInstanceIdentifierToServiceInstanceID("cf-a8051869-696b-4031-a290-8f45588f308c")
+			Expect(actual).To(Equal("a8051869-696b-4031-a290-8f45588f308c"))
+		})
+
+		It("handles '_'s in the dbPrefix", func() {
+			broker.dbPrefix = "with-dash_underscore"
+			actual := broker.dbInstanceIdentifierToServiceInstanceID("with-dash-underscore-123")
+			Expect(actual).To(Equal("123"))
+		})
+	})
+})


### PR DESCRIPTION
## What

The routine that updates the master passwords if the seed has changed
had a problem where it would occasionally use the wrong password,
meaning that the broker could no longer access the instance.

This is caused because the function used to determine the CF instanceID
from the RDS instanceID was stripping too much from the front of the
dbInstanceID. `strings.TrimLeft` takes a character set as its second
argument[1], and strips from the left all characters in that set up to the
first character that's not in the set. This meant that if some of the
starting characters in the CF instanceID were included in the dbPrefix,
they'd get stripped as well.

Replacing this with `strings.TrimPrefix`[2] does what's indended. This
also exposed another bug in the handling of '_' in the dbPrefix which
also needed to be addressed with a `Replace` call.

[1] https://golang.org/pkg/strings/#TrimLeft
[2] https://golang.org/pkg/strings/#TrimPrefix
## How to review

Code review.  Verify the tests pass.
## Who can review

Anyone but myself
