### PR TITLE
Treat databases that no longer exist as deleted

### DIFF
--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -185,7 +185,8 @@ func (b *RDSBroker) Deprovision(instanceID string, details brokerapi.Deprovision
 
 	if err := b.dbInstance.Delete(b.dbInstanceIdentifier(instanceID), skipDBInstanceFinalSnapshot); err != nil {
 		if err == awsrds.ErrDBInstanceDoesNotExist {
-			return false, brokerapi.ErrInstanceDoesNotExist
+			b.logger.Info(fmt.Sprintf("Database %v had already been deleted when deprovisioning.", instanceID))
+			return false, nil
 		}
 		return false, err
 	}

--- a/rdsbroker/broker_test.go
+++ b/rdsbroker/broker_test.go
@@ -1168,10 +1168,9 @@ var _ = Describe("RDS Broker", func() {
 					dbInstance.DeleteError = awsrds.ErrDBInstanceDoesNotExist
 				})
 
-				It("returns the proper error", func() {
+				It("does not return an error", func() {
 					_, err := rdsBroker.Deprovision(instanceID, deprovisionDetails, acceptsIncomplete)
-					Expect(err).To(HaveOccurred())
-					Expect(err).To(Equal(brokerapi.ErrInstanceDoesNotExist))
+					Expect(err).ToNot(HaveOccurred())
 				})
 			})
 		})


### PR DESCRIPTION
# What

Previously if an RDS instance was already deleted and the user attempted to delete it, it would cause the broker to no longer allow you to create or delete any other database.

This change treats a database being missing (either because we removed it or RDS did) as a successful deletion, because it already has been.

Completed while on support, task from the PaaS Improvements document.
# How to test
- Create a posgres service in a CF environment
- Remove the service RDS instance using the AWS tools
- Delete the (now missing) postgres service in the CF environment
- Observe that CF says it was successfully deleted
# Who can review

Not @jonty.
