### PR TITLE
WIP: 127970229 final snapshot

### DIFF
--- a/awsrds/db_instance.go
+++ b/awsrds/db_instance.go
@@ -10,6 +10,7 @@ type DBInstance interface {
 	Create(ID string, dbInstanceDetails DBInstanceDetails) error
 	Modify(ID string, dbInstanceDetails DBInstanceDetails, applyImmediately bool) error
 	Delete(ID string, skipFinalSnapshot bool) error
+	GetTag(ID, tagKey string) (string, error)
 }
 
 type DBInstanceDetails struct {

--- a/awsrds/fakes/fake_db_instance.go
+++ b/awsrds/fakes/fake_db_instance.go
@@ -31,6 +31,10 @@ type FakeDBInstance struct {
 	DeleteID                string
 	DeleteSkipFinalSnapshot bool
 	DeleteError             error
+
+	GetTagKey   string
+	GetTagValue string
+	GetTagError error
 }
 
 func (f *FakeDBInstance) Describe(ID string) (awsrds.DBInstanceDetails, error) {
@@ -38,6 +42,14 @@ func (f *FakeDBInstance) Describe(ID string) (awsrds.DBInstanceDetails, error) {
 	f.DescribeID = ID
 
 	return f.DescribeDBInstanceDetails, f.DescribeError
+}
+
+func (f *FakeDBInstance) GetTag(ID, tagKey string) (string, error) {
+	f.DescribeCalled = true
+	f.GetTagKey = tagKey
+	f.DescribeID = ID
+
+	return f.GetTagValue, f.GetTagError
 }
 
 func (f *FakeDBInstance) DescribeByTag(tagKey, tagValue string) ([]*awsrds.DBInstanceDetails, error) {

--- a/awsrds/rds_db_instance.go
+++ b/awsrds/rds_db_instance.go
@@ -101,6 +101,51 @@ func (r *RDSDBInstance) DescribeByTag(tagKey, tagValue string) ([]*DBInstanceDet
 	return dbInstanceDetails, nil
 }
 
+func (r *RDSDBInstance) GetTag(ID, tagKey string) (string, error) {
+
+	describeDBInstancesInput := &rds.DescribeDBInstancesInput{
+		DBInstanceIdentifier: aws.String(ID),
+	}
+
+	r.logger.Debug("get-tag", lager.Data{"input": describeDBInstancesInput})
+
+	myInstance, err := r.rdssvc.DescribeDBInstances(describeDBInstancesInput)
+	if err != nil {
+		r.logger.Error("aws-rds-error", err)
+		if awsErr, ok := err.(awserr.Error); ok {
+			if reqErr, ok := err.(awserr.RequestFailure); ok {
+				if reqErr.StatusCode() == 404 {
+					return "", ErrDBInstanceDoesNotExist
+				}
+			}
+			return "", errors.New(awsErr.Code() + ": " + awsErr.Message())
+		}
+		return "", err
+	}
+
+	dbArn, err := r.dbInstanceARN(*myInstance.DBInstances[0].DBInstanceIdentifier)
+	if err != nil {
+		return "", err
+	}
+
+	listTagsForResourceInput := &rds.ListTagsForResourceInput{
+		ResourceName: aws.String(dbArn),
+	}
+
+	listTagsForResourceOutput, err := r.rdssvc.ListTagsForResource(listTagsForResourceInput)
+	if err != nil {
+		return "", err
+	}
+
+	for _, t := range listTagsForResourceOutput.TagList {
+		if *t.Key == tagKey {
+			return *t.Value, nil
+		}
+	}
+
+	return "", nil
+}
+
 func (r *RDSDBInstance) Create(ID string, dbInstanceDetails DBInstanceDetails) error {
 	createDBInstanceInput := r.buildCreateDBInstanceInput(ID, dbInstanceDetails)
 

--- a/awsrds/rds_db_instance.go
+++ b/awsrds/rds_db_instance.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -451,7 +450,7 @@ func (r *RDSDBInstance) buildDeleteDBInstanceInput(ID string, skipFinalSnapshot 
 }
 
 func (r *RDSDBInstance) dbSnapshotName(ID string) string {
-	return fmt.Sprintf("rds-broker-%s-%s", ID, time.Now().Format("2006-01-02-15-04-05"))
+	return fmt.Sprintf("%s-final-snapshot", ID)
 }
 
 func (r *RDSDBInstance) dbInstanceARN(ID string) (string, error) {

--- a/awsrds/rds_db_instance_test.go
+++ b/awsrds/rds_db_instance_test.go
@@ -1249,7 +1249,7 @@ var _ = Describe("RDS DB Instance", func() {
 		Context("when does not skip the final snapshot", func() {
 			BeforeEach(func() {
 				skipFinalSnapshot = false
-				finalDBSnapshotIdentifier = "rds-broker-" + dbInstanceIdentifier
+				finalDBSnapshotIdentifier = dbInstanceIdentifier + "-final-snapshot"
 			})
 
 			It("returns the proper DB Instance", func() {

--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -23,6 +23,9 @@ const instanceIDLogKey = "instance-id"
 const bindingIDLogKey = "binding-id"
 const detailsLogKey = "details"
 const acceptsIncompleteLogKey = "acceptsIncomplete"
+const updateParametersLogKey = "updateParameters"
+const servicePlanLogKey = "servicePlan"
+const dbInstanceDetailsLogKey = "dbInstanceDetails"
 
 var rdsStatus2State = map[string]string{
 	"available":                    brokerapi.LastOperationSucceeded,
@@ -145,6 +148,7 @@ func (b *RDSBroker) Update(instanceID string, details brokerapi.UpdateDetails, a
 		if err := updateParameters.Validate(); err != nil {
 			return false, err
 		}
+		b.logger.Debug("update-parsed-params", lager.Data{updateParametersLogKey: updateParameters,})
 	}
 
 	service, ok := b.catalog.FindService(details.ServiceID)
@@ -473,6 +477,14 @@ func (b *RDSBroker) createDBInstance(instanceID string, servicePlan ServicePlan,
 
 func (b *RDSBroker) modifyDBInstance(instanceID string, servicePlan ServicePlan, updateParameters UpdateParameters, details brokerapi.UpdateDetails) *awsrds.DBInstanceDetails {
 	dbInstanceDetails := b.dbInstanceFromPlan(servicePlan)
+
+	b.logger.Debug("modifyDBInstance", lager.Data{
+		instanceIDLogKey:        instanceID,
+		detailsLogKey:           details,
+		updateParametersLogKey:  updateParameters,
+		servicePlanLogKey:       servicePlan,
+		dbInstanceDetailsLogKey: dbInstanceDetails,
+	})
 
 	if updateParameters.BackupRetentionPeriod > 0 {
 		dbInstanceDetails.BackupRetentionPeriod = updateParameters.BackupRetentionPeriod

--- a/rdsbroker/parameters.go
+++ b/rdsbroker/parameters.go
@@ -1,21 +1,43 @@
 package rdsbroker
 
+import (
+	"errors"
+)
+
 type ProvisionParameters struct {
-	BackupRetentionPeriod      int64  `mapstructure:"backup_retention_period"`
-	CharacterSetName           string `mapstructure:"character_set_name"`
-	DBName                     string `mapstructure:"dbname"`
-	PreferredBackupWindow      string `mapstructure:"preferred_backup_window"`
-	PreferredMaintenanceWindow string `mapstructure:"preferred_maintenance_window"`
+	BackupRetentionPeriod      int64
+	CharacterSetName           string
+	DBName                     string
+	PreferredBackupWindow      string
+	PreferredMaintenanceWindow string
+	SkipFinalSnapshot          string `mapstructure:"skip_final_snapshot"`
 }
 
 type UpdateParameters struct {
-	ApplyImmediately           bool   `mapstructure:"apply_immediately"`
-	BackupRetentionPeriod      int64  `mapstructure:"backup_retention_period"`
-	PreferredBackupWindow      string `mapstructure:"preferred_backup_window"`
-	PreferredMaintenanceWindow string `mapstructure:"preferred_maintenance_window"`
+	ApplyImmediately           bool
+	BackupRetentionPeriod      int64
+	PreferredBackupWindow      string
+	PreferredMaintenanceWindow string
+	SkipFinalSnapshot          string `mapstructure:"skip_final_snapshot"`
 }
 
 type BindParameters struct {
 	// This is currently empty, but preserved to make it easier to add
 	// bind-time parameters in future.
+}
+
+func Validate_SkipFinalSnapshot(SkipFinalSnapshot string) error {
+	switch SkipFinalSnapshot {
+	case "true", "false", "":
+		return nil
+	}
+	return errors.New("skip_final_snapshot must be set to true or false, or not set at all")
+}
+
+func (pp *ProvisionParameters) Validate() error {
+	return Validate_SkipFinalSnapshot(pp.SkipFinalSnapshot)
+}
+
+func (pp *UpdateParameters) Validate() error {
+	return Validate_SkipFinalSnapshot(pp.SkipFinalSnapshot)
 }


### PR DESCRIPTION
## What

We have disabled all other parameters that could be provided by the user, on the command execution. This has caused the need to modify/disable related tests.

We've decided, to change the name from `rds-broker-rdsbroker-XXXIDXXX-timestamp` to `rdsbroker-XXXIDXXX-final-snapshot`. This removes duplication and allows for easier recognition of the final snapshots. Creation time is still available in snapshot properties.

This parameter, will provide users with an option to set SkipFinalSnapshot setting, during the execution of `cf create-service`.

We've developed a new method for `RDSDBInstance`, which can retrieve a given tag from RDS DB instance. It will be used to check if `skip_final_snapshot` was set during provision phase.
## Before Merge

This PR relies on other associated PRs, `paas-cf` and `paas-aws-broker-boshrelease`, to be merged beforehand.
