### PR TITLE
[#132312331] Fix async delete for updated brokerapi library.

### DIFF
--- a/rdsbroker/broker_test.go
+++ b/rdsbroker/broker_test.go
@@ -1158,8 +1158,9 @@ var _ = Describe("RDS Broker", func() {
 
 		It("returns the proper response", func() {
 			spec, err := rdsBroker.Deprovision(instanceID, deprovisionDetails, acceptsIncomplete)
-			Expect(spec.IsAsync).To(BeTrue())
 			Expect(err).ToNot(HaveOccurred())
+			Expect(spec.IsAsync).To(BeTrue())
+			Expect(spec.OperationData).To(Equal("deprovision"))
 		})
 
 		It("makes the proper calls", func() {
@@ -1539,6 +1540,12 @@ var _ = Describe("RDS Broker", func() {
 			Context("when the DB Instance does not exists", func() {
 				BeforeEach(func() {
 					dbInstance.DescribeError = awsrds.ErrDBInstanceDoesNotExist
+				})
+
+				It("returns success for a deprovision operation", func() {
+					lastOperationResponse, err := rdsBroker.LastOperation(instanceID, "deprovision")
+					Expect(err).NotTo(HaveOccurred())
+					Expect(lastOperationResponse.State).To(Equal(brokerapi.Succeeded))
 				})
 
 				It("returns the proper error", func() {


### PR DESCRIPTION
## What

We hit an issue with async deletion of service instances following the
switch of the brokerapi from the frodenas fork to the pivotal-cf
version. The frodenas version returns a 410 Gone if the broker
implementation returns an ErrInstanceDoesNotExist[1], whereas the
Pivotal-cf version returns a 404 Not Found[2]. The service broker API
docs specify that a 410 can be returned to indicate to CF that service
deletion has completed, and this is how this was working previously. A
404 is treated as an error, so CF keeps on polling for deletion to
complete.

This therefore updates the broker to return a succeeded response to the
lastOperation polling when DB instance has gone. In order to only do
this in the case of delete requests, we return a "deprovision" string
in the operation field from the Deprovision call. Cloudfoundry provides
this string to the lastOperation call[3] so we can test for it.

[1]https://github.com/frodenas/brokerapi/blob/e43c1f9/api.go#L368-L370
[2]https://github.com/pivotal-cf/brokerapi/blob/bd7932b/api.go#L334-L338
[3]https://docs.cloudfoundry.org/services/api.html#polling

## How to review

Manually upload a binary compiled from this branch to CF (as described in #5). The updated binary will need to be uploaded to both rds_broker machines.

Verify that the custom-acceptance-tests pass with this in place.

## Who can review

Anyone but @richardc or myself.