### PR TITLE
Configure aws partition.

### DIFF
--- a/awsrds/rds_db_instance.go
+++ b/awsrds/rds_db_instance.go
@@ -13,23 +13,26 @@ import (
 )
 
 type RDSDBInstance struct {
-	region string
-	rdssvc *rds.RDS
-	stssvc *sts.STS
-	logger lager.Logger
+	region    string
+	partition string
+	rdssvc    *rds.RDS
+	stssvc    *sts.STS
+	logger    lager.Logger
 }
 
 func NewRDSDBInstance(
 	region string,
+	partition string,
 	rdssvc *rds.RDS,
 	stssvc *sts.STS,
 	logger lager.Logger,
 ) *RDSDBInstance {
 	return &RDSDBInstance{
-		region: region,
-		rdssvc: rdssvc,
-		stssvc: stssvc,
-		logger: logger.Session("db-instance"),
+		region:    region,
+		partition: partition,
+		rdssvc:    rdssvc,
+		stssvc:    stssvc,
+		logger:    logger.Session("db-instance"),
 	}
 }
 
@@ -459,7 +462,7 @@ func (r *RDSDBInstance) dbInstanceARN(ID string) (string, error) {
 		return "", err
 	}
 
-	return fmt.Sprintf("arn:aws:rds:%s:%s:db:%s", r.region, userAccount, ID), nil
+	return fmt.Sprintf("arn:%s:rds:%s:%s:db:%s", r.partition, r.region, userAccount, ID), nil
 }
 
 func (r *RDSDBInstance) allowMajorVersionUpgrade(newEngineVersion, oldEngineVersion string) bool {

--- a/awsrds/rds_db_instance_test.go
+++ b/awsrds/rds_db_instance_test.go
@@ -23,6 +23,7 @@ import (
 var _ = Describe("RDS DB Instance", func() {
 	var (
 		region               string
+		partition            string
 		dbInstanceIdentifier string
 
 		awsSession *session.Session
@@ -41,6 +42,7 @@ var _ = Describe("RDS DB Instance", func() {
 
 	BeforeEach(func() {
 		region = "rds-region"
+		partition = "rds-partition"
 		dbInstanceIdentifier = "cf-instance-id"
 	})
 
@@ -54,7 +56,7 @@ var _ = Describe("RDS DB Instance", func() {
 		testSink = lagertest.NewTestSink()
 		logger.RegisterSink(testSink)
 
-		rdsDBInstance = NewRDSDBInstance(region, rdssvc, stssvc, logger)
+		rdsDBInstance = NewRDSDBInstance(region, partition, rdssvc, stssvc, logger)
 	})
 
 	var _ = Describe("Describe", func() {
@@ -368,7 +370,7 @@ var _ = Describe("RDS DB Instance", func() {
 
 					listTagsForResourceInput := r.Params.(*rds.ListTagsForResourceInput)
 					gotARN := *listTagsForResourceInput.ResourceName
-					expectedARN := fmt.Sprintf("arn:aws:rds:%s:123456789012:db:%s", region, dbInstanceIdentifier)
+					expectedARN := fmt.Sprintf("arn:%s:rds:%s:123456789012:db:%s", partition, region, dbInstanceIdentifier)
 					Expect(gotARN).To(HavePrefix(expectedARN))
 
 					data := r.Data.(*rds.ListTagsForResourceOutput)
@@ -854,7 +856,7 @@ var _ = Describe("RDS DB Instance", func() {
 			modifyDBInstanceError = nil
 
 			addTagsToResourceInput = &rds.AddTagsToResourceInput{
-				ResourceName: aws.String("arn:aws:rds:rds-region:" + account + ":db:" + dbInstanceIdentifier),
+				ResourceName: aws.String("arn:" + partition + ":rds:rds-region:" + account + ":db:" + dbInstanceIdentifier),
 				Tags: []*rds.Tag{
 					&rds.Tag{
 						Key:   aws.String("Owner"),

--- a/config.go
+++ b/config.go
@@ -62,6 +62,7 @@ func (c Config) Validate() error {
 		return errors.New("Must provide a non-empty StateEncryptionKey")
 	}
 
+	c.RDSConfig.FillDefaults()
 	if err := c.RDSConfig.Validate(); err != nil {
 		return fmt.Errorf("Validating RDS configuration: %s", err)
 	}

--- a/config.go
+++ b/config.go
@@ -11,11 +11,11 @@ import (
 )
 
 type Config struct {
-	LogLevel           string           `json:"log_level"`
-	Username           string           `json:"username"`
-	Password           string           `json:"password"`
-	StateEncryptionKey string           `json:"state_encryption_key"`
-	RDSConfig          rdsbroker.Config `json:"rds_config"`
+	LogLevel           string            `json:"log_level"`
+	Username           string            `json:"username"`
+	Password           string            `json:"password"`
+	StateEncryptionKey string            `json:"state_encryption_key"`
+	RDSConfig          *rdsbroker.Config `json:"rds_config"`
 }
 
 func LoadConfig(configFile string) (config *Config, err error) {
@@ -38,11 +38,17 @@ func LoadConfig(configFile string) (config *Config, err error) {
 		return config, err
 	}
 
+	config.FillDefaults()
+
 	if err = config.Validate(); err != nil {
 		return config, fmt.Errorf("Validating config contents: %s", err)
 	}
 
 	return config, nil
+}
+
+func (c Config) FillDefaults() {
+	c.RDSConfig.FillDefaults()
 }
 
 func (c Config) Validate() error {
@@ -62,7 +68,6 @@ func (c Config) Validate() error {
 		return errors.New("Must provide a non-empty StateEncryptionKey")
 	}
 
-	c.RDSConfig.FillDefaults()
 	if err := c.RDSConfig.Validate(); err != nil {
 		return fmt.Errorf("Validating RDS configuration: %s", err)
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -18,7 +18,7 @@ var _ = Describe("Config", func() {
 			Username:           "broker-username",
 			Password:           "broker-password",
 			StateEncryptionKey: "key",
-			RDSConfig: rdsbroker.Config{
+			RDSConfig: &rdsbroker.Config{
 				Region:             "rds-region",
 				DBPrefix:           "cf",
 				BrokerName:         "mybroker",
@@ -71,7 +71,7 @@ var _ = Describe("Config", func() {
 		})
 
 		It("returns error if RDS configuration is not valid", func() {
-			config.RDSConfig = rdsbroker.Config{}
+			config.RDSConfig = &rdsbroker.Config{}
 
 			err := config.Validate()
 			Expect(err).To(HaveOccurred())

--- a/config_test.go
+++ b/config_test.go
@@ -22,6 +22,7 @@ var _ = Describe("Config", func() {
 				Region:             "rds-region",
 				DBPrefix:           "cf",
 				BrokerName:         "mybroker",
+				AWSPartition:       "rds-partition",
 				MasterPasswordSeed: "secret",
 			},
 		}

--- a/main.go
+++ b/main.go
@@ -84,7 +84,7 @@ func main() {
 
 	sqlProvider := sqlengine.NewProviderService(logger, config.StateEncryptionKey)
 
-	serviceBroker := rdsbroker.New(config.RDSConfig, dbInstance, sqlProvider, logger)
+	serviceBroker := rdsbroker.New(*config.RDSConfig, dbInstance, sqlProvider, logger)
 
 	go serviceBroker.CheckAndRotateCredentials()
 

--- a/main.go
+++ b/main.go
@@ -80,7 +80,7 @@ func main() {
 	rdssvc := rds.New(awsSession)
 	stssvc := sts.New(awsSession)
 
-	dbInstance := awsrds.NewRDSDBInstance(config.RDSConfig.Region, rdssvc, stssvc, logger)
+	dbInstance := awsrds.NewRDSDBInstance(config.RDSConfig.Region, config.RDSConfig.AWSPartition, rdssvc, stssvc, logger)
 
 	sqlProvider := sqlengine.NewProviderService(logger, config.StateEncryptionKey)
 

--- a/rdsbroker/config.go
+++ b/rdsbroker/config.go
@@ -9,6 +9,7 @@ type Config struct {
 	Region                       string  `json:"region"`
 	DBPrefix                     string  `json:"db_prefix"`
 	BrokerName                   string  `json:"broker_name"`
+	AWSPartition                 string  `json:"aws_partition"`
 	MasterPasswordSeed           string  `json:"master_password_seed"`
 	AllowUserProvisionParameters bool    `json:"allow_user_provision_parameters"`
 	AllowUserUpdateParameters    bool    `json:"allow_user_update_parameters"`
@@ -27,6 +28,10 @@ func (c Config) Validate() error {
 
 	if c.BrokerName == "" {
 		return errors.New("Must provide a non-empty BrokerName")
+	}
+
+	if c.AWSPartition == "" {
+		c.AWSPartition = "aws"
 	}
 
 	if c.MasterPasswordSeed == "" {

--- a/rdsbroker/config.go
+++ b/rdsbroker/config.go
@@ -17,6 +17,12 @@ type Config struct {
 	Catalog                      Catalog `json:"catalog"`
 }
 
+func (c *Config) FillDefaults() {
+	if c.AWSPartition == "" {
+		c.AWSPartition = "aws"
+	}
+}
+
 func (c Config) Validate() error {
 	if c.Region == "" {
 		return errors.New("Must provide a non-empty Region")
@@ -28,10 +34,6 @@ func (c Config) Validate() error {
 
 	if c.BrokerName == "" {
 		return errors.New("Must provide a non-empty BrokerName")
-	}
-
-	if c.AWSPartition == "" {
-		c.AWSPartition = "aws"
 	}
 
 	if c.MasterPasswordSeed == "" {

--- a/rdsbroker/config_test.go
+++ b/rdsbroker/config_test.go
@@ -41,9 +41,8 @@ var _ = Describe("Config", func() {
 		})
 
 		It("preserves aws partition if not empty", func() {
-			config.AWSPartition = "not-empty-partition"
 			config.FillDefaults()
-			Expect(config.AWSPartition).To(Equal("not-empty-partition"))
+			Expect(config.AWSPartition).To(Equal("rds-partition"))
 		})
 	})
 

--- a/rdsbroker/config_test.go
+++ b/rdsbroker/config_test.go
@@ -16,6 +16,7 @@ var _ = Describe("Config", func() {
 			DBPrefix:           "cf",
 			MasterPasswordSeed: "secret",
 			BrokerName:         "mybroker",
+			AWSPartition:       "rds-partition",
 			Catalog: Catalog{
 				[]Service{
 					Service{

--- a/rdsbroker/config_test.go
+++ b/rdsbroker/config_test.go
@@ -29,6 +29,24 @@ var _ = Describe("Config", func() {
 		}
 	)
 
+	Describe("FillDefaults", func() {
+		BeforeEach(func() {
+			config = validConfig
+		})
+
+		It("sets default aws partition if empty", func() {
+			config.AWSPartition = ""
+			config.FillDefaults()
+			Expect(config.AWSPartition).To(Equal("aws"))
+		})
+
+		It("preserves aws partition if not empty", func() {
+			config.AWSPartition = "not-empty-partition"
+			config.FillDefaults()
+			Expect(config.AWSPartition).To(Equal("not-empty-partition"))
+		})
+	})
+
 	Describe("Validate", func() {
 		BeforeEach(func() {
 			config = validConfig


### PR DESCRIPTION
So that partitions other than `aws`, like `aws-us-gov` and `aws-cn`, can be used.