### PR TITLE
[WIP] Optionally allow users to configure storage.

### DIFF
--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -2,6 +2,7 @@ package rdsbroker
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -122,6 +123,14 @@ func (b *RDSBroker) Provision(instanceID string, details brokerapi.ProvisionDeta
 	}
 
 	createDBInstance := b.createDBInstance(instanceID, servicePlan, provisionParameters, details)
+
+	if provisionParameters.AllocatedStorage > 0 {
+		if err := b.validateStorage(provisionParameters.AllocatedStorage, servicePlan.RDSProperties); err != nil {
+			return provisioningResponse, false, err
+		}
+		createDBInstance.AllocatedStorage = provisionParameters.AllocatedStorage
+	}
+
 	if err := b.dbInstance.Create(b.dbInstanceIdentifier(instanceID), *createDBInstance); err != nil {
 		return provisioningResponse, false, err
 	}
@@ -148,7 +157,7 @@ func (b *RDSBroker) Update(instanceID string, details brokerapi.UpdateDetails, a
 		if err := updateParameters.Validate(); err != nil {
 			return false, err
 		}
-		b.logger.Debug("update-parsed-params", lager.Data{updateParametersLogKey: updateParameters,})
+		b.logger.Debug("update-parsed-params", lager.Data{updateParametersLogKey: updateParameters})
 	}
 
 	service, ok := b.catalog.FindService(details.ServiceID)
@@ -166,6 +175,14 @@ func (b *RDSBroker) Update(instanceID string, details brokerapi.UpdateDetails, a
 	}
 
 	modifyDBInstance := b.modifyDBInstance(instanceID, servicePlan, updateParameters, details)
+
+	if servicePlan.RDSProperties.ConfigureAllocatedStorage && updateParameters.AllocatedStorage > 0 {
+		if err := b.validateStorage(updateParameters.AllocatedStorage, servicePlan.RDSProperties); err != nil {
+			return false, err
+		}
+		modifyDBInstance.AllocatedStorage = updateParameters.AllocatedStorage
+	}
+
 	if err := b.dbInstance.Modify(b.dbInstanceIdentifier(instanceID), *modifyDBInstance, updateParameters.ApplyImmediately); err != nil {
 		if err == awsrds.ErrDBInstanceDoesNotExist {
 			return false, brokerapi.ErrInstanceDoesNotExist
@@ -625,4 +642,15 @@ func (b *RDSBroker) dbTags(action, serviceID, planID, organizationID, spaceID, s
 	}
 
 	return tags
+}
+
+func (b *RDSBroker) validateStorage(storage int64, rp RDSProperties) error {
+	if !rp.ConfigureAllocatedStorage {
+		return errors.New("Plan does not allow configuring storage")
+	}
+	if (rp.MinAllocatedStorage > 0 && storage < rp.MinAllocatedStorage) ||
+		(rp.MaxAllocatedStorage > 0 && storage >= rp.MaxAllocatedStorage) {
+		return fmt.Errorf("%d %d", rp.MinAllocatedStorage, rp.MaxAllocatedStorage)
+	}
+	return nil
 }

--- a/rdsbroker/catalog.go
+++ b/rdsbroker/catalog.go
@@ -5,9 +5,6 @@ import (
 	"strings"
 )
 
-const minAllocatedStorage = 5
-const maxAllocatedStorage = 6144
-
 type Catalog struct {
 	Services []Service `json:"services,omitempty"`
 }
@@ -65,6 +62,9 @@ type RDSProperties struct {
 	Engine                     string   `json:"engine"`
 	EngineVersion              string   `json:"engine_version"`
 	AllocatedStorage           int64    `json:"allocated_storage"`
+	ConfigureAllocatedStorage  bool     `json:"configure_allocated_storage"`
+	MinAllocatedStorage        int64    `json:"min_allocated_storage"`
+	MaxAllocatedStorage        int64    `json:"max_allocated_storage"`
 	AutoMinorVersionUpgrade    bool     `json:"auto_minor_version_upgrade,omitempty"`
 	AvailabilityZone           string   `json:"availability_zone,omitempty"`
 	BackupRetentionPeriod      int64    `json:"backup_retention_period,omitempty"`

--- a/rdsbroker/parameters.go
+++ b/rdsbroker/parameters.go
@@ -11,6 +11,7 @@ type ProvisionParameters struct {
 	PreferredBackupWindow      string
 	PreferredMaintenanceWindow string
 	SkipFinalSnapshot          string `mapstructure:"skip_final_snapshot"`
+	AllocatedStorage           int64  `mapstructure:"allocated_storage"`
 }
 
 type UpdateParameters struct {
@@ -19,6 +20,7 @@ type UpdateParameters struct {
 	PreferredBackupWindow      string
 	PreferredMaintenanceWindow string
 	SkipFinalSnapshot          string `mapstructure:"skip_final_snapshot"`
+	AllocatedStorage           int64  `mapstructure:"allocated_storage"`
 }
 
 type BindParameters struct {


### PR DESCRIPTION
Context: the [current broker](https://github.com/18f/aws-broker) in use at 18f allows users to configure allocated storage. We're looking to switch to this broker soon and would like to keep feature parity, so here's a patch that allows users to configure storage within specified limits for specified plans. I'll backfill tests if you're are open to adding this feature.