### PR TITLE
[WIP] Configure read replicas on update.

### DIFF
--- a/Godeps/_workspace/src/github.com/frodenas/brokerapi/response.go
+++ b/Godeps/_workspace/src/github.com/frodenas/brokerapi/response.go
@@ -21,13 +21,16 @@ type BindingResponse struct {
 }
 
 type CredentialsHash struct {
-	Host     string `json:"host,omitempty"`
-	Port     int64  `json:"port,omitempty"`
-	Name     string `json:"name,omitempty"`
-	Username string `json:"username,omitempty"`
-	Password string `json:"password,omitempty"`
-	URI      string `json:"uri,omitempty"`
-	JDBCURI  string `json:"jdbcUrl,omitempty"`
+	Host            string   `json:"host,omitempty"`
+	Port            int64    `json:"port,omitempty"`
+	Name            string   `json:"name,omitempty"`
+	Username        string   `json:"username,omitempty"`
+	Password        string   `json:"password,omitempty"`
+	URI             string   `json:"uri,omitempty"`
+	JDBCURI         string   `json:"jdbcUrl,omitempty"`
+	Replicas        []string `json:"replicas,omitempty"`
+	ReplicaURIs     []string `json:"replica_uris,omitempty"`
+	ReplicaJDBCURIs []string `json:"replica_uris,omitempty"`
 }
 
 type LastOperationResponse struct {

--- a/awsrds/db_instance.go
+++ b/awsrds/db_instance.go
@@ -53,5 +53,6 @@ type DBInstanceDetails struct {
 }
 
 var (
-	ErrDBInstanceDoesNotExist = errors.New("rds db instance does not exist")
+	ErrDBInstanceDoesNotExist            = errors.New("rds db instance does not exist")
+	ErrCannotCreateReplicaWithoutBackups = errors.New("cannot create read replicas without automatic backups")
 )

--- a/awsrds/db_instance.go
+++ b/awsrds/db_instance.go
@@ -6,6 +6,7 @@ import (
 
 type DBInstance interface {
 	Describe(ID string) (DBInstanceDetails, error)
+	DescribeMany(IDs []string) ([]DBInstanceDetails, error)
 	DescribeByTag(TagName, TagValue string) ([]*DBInstanceDetails, error)
 	Create(ID string, dbInstanceDetails DBInstanceDetails) error
 	Modify(ID string, dbInstanceDetails DBInstanceDetails, applyImmediately bool) error

--- a/awsrds/db_instance.go
+++ b/awsrds/db_instance.go
@@ -16,6 +16,7 @@ type DBInstance interface {
 
 type DBInstanceDetails struct {
 	Identifier                 string
+	SourceIdentifier           string
 	Status                     string
 	DBInstanceClass            string
 	Engine                     string

--- a/awsrds/db_instance.go
+++ b/awsrds/db_instance.go
@@ -46,6 +46,8 @@ type DBInstanceDetails struct {
 	StorageType                string
 	Tags                       map[string]string
 	VpcSecurityGroupIds        []string
+	ReadReplicaCount           int
+	ReadReplicaIds             []string
 }
 
 var (

--- a/awsrds/fakes/fake_db_instance.go
+++ b/awsrds/fakes/fake_db_instance.go
@@ -10,6 +10,11 @@ type FakeDBInstance struct {
 	DescribeDBInstanceDetails awsrds.DBInstanceDetails
 	DescribeError             error
 
+	DescribeManyCalled            bool
+	DescribeManyIDs               []string
+	DescribeManyDBInstanceDetails []awsrds.DBInstanceDetails
+	DescribeManyError             error
+
 	DescribeByTagCalled            bool
 	DescribeByTagKey               string
 	DescribeByTagValue             string
@@ -42,6 +47,13 @@ func (f *FakeDBInstance) Describe(ID string) (awsrds.DBInstanceDetails, error) {
 	f.DescribeID = ID
 
 	return f.DescribeDBInstanceDetails, f.DescribeError
+}
+
+func (f *FakeDBInstance) DescribeMany(IDs []string) ([]awsrds.DBInstanceDetails, error) {
+	f.DescribeManyCalled = true
+	f.DescribeManyIDs = IDs
+
+	return f.DescribeManyDBInstanceDetails, f.DescribeManyError
 }
 
 func (f *FakeDBInstance) GetTag(ID, tagKey string) (string, error) {

--- a/awsrds/rds_db_instance.go
+++ b/awsrds/rds_db_instance.go
@@ -337,6 +337,7 @@ func (r *RDSDBInstance) deleteInstance(ID string, skipFinalSnapshot bool) error 
 func (r *RDSDBInstance) buildDBInstance(dbInstance *rds.DBInstance) DBInstanceDetails {
 	dbInstanceDetails := DBInstanceDetails{
 		Identifier:       aws.StringValue(dbInstance.DBInstanceIdentifier),
+		SourceIdentifier: aws.StringValue(dbInstance.ReadReplicaSourceDBInstanceIdentifier),
 		Status:           aws.StringValue(dbInstance.DBInstanceStatus),
 		Engine:           aws.StringValue(dbInstance.Engine),
 		EngineVersion:    aws.StringValue(dbInstance.EngineVersion),

--- a/awsrds/rds_db_instance.go
+++ b/awsrds/rds_db_instance.go
@@ -257,6 +257,10 @@ func (r *RDSDBInstance) Modify(ID string, dbInstanceDetails DBInstanceDetails, a
 		return fmt.Errorf("Migrating the RDS DB Instance engine from '%s' to '%s' is not supported", oldDBInstanceDetails.Engine, dbInstanceDetails.Engine)
 	}
 
+	if dbInstanceDetails.ReadReplicaCount > 0 && oldDBInstanceDetails.BackupRetentionPeriod == 0 {
+		return ErrCannotCreateReplicaWithoutBackups
+	}
+
 	modifyDBInstanceInput := r.buildModifyDBInstanceInput(ID, dbInstanceDetails, oldDBInstanceDetails, applyImmediately)
 
 	sanitizedDBInstanceInput := *modifyDBInstanceInput

--- a/awsrds/rds_db_instance_test.go
+++ b/awsrds/rds_db_instance_test.go
@@ -1208,6 +1208,19 @@ var _ = Describe("RDS DB Instance", func() {
 				})
 			})
 		})
+
+		Context("when backups are not configured", func() {
+			BeforeEach(func() {
+				describeDBInstance.BackupRetentionPeriod = aws.Int64(0)
+				dbInstanceDetails.ReadReplicaCount = 1
+			})
+
+			It("returns an error if replicas requested", func() {
+				err := rdsDBInstance.Modify(dbInstanceIdentifier, dbInstanceDetails, applyImmediately)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(Equal(ErrCannotCreateReplicaWithoutBackups))
+			})
+		})
 	})
 
 	var _ = Describe("Delete", func() {

--- a/awsrds/rds_db_instance_test.go
+++ b/awsrds/rds_db_instance_test.go
@@ -1215,32 +1215,67 @@ var _ = Describe("RDS DB Instance", func() {
 			skipFinalSnapshot         bool
 			finalDBSnapshotIdentifier string
 
-			deleteDBInstanceError error
+			describeDBInstanceError error
+			deleteDBInstanceError   error
+
+			describeDBInstance       *rds.DBInstance
+			describeDBInstances      []*rds.DBInstance
+			describeDBInstancesInput *rds.DescribeDBInstancesInput
 		)
 
 		BeforeEach(func() {
 			skipFinalSnapshot = true
 			finalDBSnapshotIdentifier = ""
 			deleteDBInstanceError = nil
+
+			describeDBInstancesInput = &rds.DescribeDBInstancesInput{
+				DBInstanceIdentifier: aws.String(dbInstanceIdentifier),
+			}
+
+			describeDBInstance = &rds.DBInstance{
+				DBInstanceIdentifier: aws.String(dbInstanceIdentifier),
+				DBInstanceStatus:     aws.String("available"),
+				Engine:               aws.String("test-engine"),
+				EngineVersion:        aws.String("1.2.3"),
+				DBName:               aws.String("test-dbname"),
+				MasterUsername:       aws.String("test-master-username"),
+				AllocatedStorage:     aws.Int64(100),
+			}
+			describeDBInstances = []*rds.DBInstance{describeDBInstance}
 		})
 
 		JustBeforeEach(func() {
 			rdssvc.Handlers.Clear()
 
-			rdsCall = func(r *request.Request) {
-				Expect(r.Operation.Name).To(Equal("DeleteDBInstance"))
-				Expect(r.Params).To(BeAssignableToTypeOf(&rds.DeleteDBInstanceInput{}))
-				params := r.Params.(*rds.DeleteDBInstanceInput)
-				Expect(params.DBInstanceIdentifier).To(Equal(aws.String(dbInstanceIdentifier)))
-				if finalDBSnapshotIdentifier != "" {
-					Expect(*params.FinalDBSnapshotIdentifier).To(ContainSubstring(finalDBSnapshotIdentifier))
-				} else {
-					Expect(params.FinalDBSnapshotIdentifier).To(BeNil())
-				}
-				Expect(params.SkipFinalSnapshot).To(Equal(aws.Bool(skipFinalSnapshot)))
-				r.Error = deleteDBInstanceError
+			handlers := []func(r *request.Request){
+				func(r *request.Request) {
+					Expect(r.Operation.Name).To(Equal("DescribeDBInstances"))
+					Expect(r.Params).To(BeAssignableToTypeOf(&rds.DescribeDBInstancesInput{}))
+					Expect(r.Params).To(Equal(describeDBInstancesInput))
+					data := r.Data.(*rds.DescribeDBInstancesOutput)
+					data.DBInstances = describeDBInstances
+					r.Error = describeDBInstanceError
+				},
+				func(r *request.Request) {
+					Expect(r.Operation.Name).To(Equal("DeleteDBInstance"))
+					Expect(r.Params).To(BeAssignableToTypeOf(&rds.DeleteDBInstanceInput{}))
+					params := r.Params.(*rds.DeleteDBInstanceInput)
+					Expect(params.DBInstanceIdentifier).To(Equal(aws.String(dbInstanceIdentifier)))
+					if finalDBSnapshotIdentifier != "" {
+						Expect(*params.FinalDBSnapshotIdentifier).To(ContainSubstring(finalDBSnapshotIdentifier))
+					} else {
+						Expect(params.FinalDBSnapshotIdentifier).To(BeNil())
+					}
+					Expect(params.SkipFinalSnapshot).To(Equal(aws.Bool(skipFinalSnapshot)))
+					r.Error = deleteDBInstanceError
+				},
 			}
-			rdssvc.Handlers.Send.PushBack(rdsCall)
+			idx := 0
+
+			rdssvc.Handlers.Send.PushBack(func(r *request.Request) {
+				handlers[idx](r)
+				idx++
+			})
 		})
 
 		It("does not return error", func() {

--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -148,7 +148,7 @@ func (b *RDSBroker) Update(instanceID string, details brokerapi.UpdateDetails, a
 		if err := updateParameters.Validate(); err != nil {
 			return false, err
 		}
-		b.logger.Debug("update-parsed-params", lager.Data{updateParametersLogKey: updateParameters,})
+		b.logger.Debug("update-parsed-params", lager.Data{updateParametersLogKey: updateParameters})
 	}
 
 	service, ok := b.catalog.FindService(details.ServiceID)
@@ -261,6 +261,14 @@ func (b *RDSBroker) Bind(instanceID, bindingID string, details brokerapi.BindDet
 	masterUsername = dbInstanceDetails.MasterUsername
 	dbName = b.dbNameFromDetails(instanceID, dbInstanceDetails)
 
+	var replicas []awsrds.DBInstanceDetails
+	if len(dbInstanceDetails.ReadReplicaIds) > 0 {
+		replicas, err = b.dbInstance.DescribeMany(dbInstanceDetails.ReadReplicaIds)
+		if err != nil {
+			return bindingResponse, err
+		}
+	}
+
 	sqlEngine, err := b.sqlProvider.GetSQLEngine(servicePlan.RDSProperties.Engine)
 	if err != nil {
 		return bindingResponse, err
@@ -276,14 +284,24 @@ func (b *RDSBroker) Bind(instanceID, bindingID string, details brokerapi.BindDet
 		return bindingResponse, err
 	}
 
+	replicaURIs := make([]string, len(replicas))
+	replicaJDBCURIs := make([]string, len(replicas))
+	for idx, replica := range replicas {
+		replicaURIs[idx] = sqlEngine.URI(replica.Address, dbPort, dbName, dbUsername, dbPassword)
+		replicaJDBCURIs[idx] = sqlEngine.JDBCURI(replica.Address, dbPort, dbName, dbUsername, dbPassword)
+	}
+
 	bindingResponse.Credentials = &brokerapi.CredentialsHash{
-		Host:     dbAddress,
-		Port:     dbPort,
-		Name:     dbName,
-		Username: dbUsername,
-		Password: dbPassword,
-		URI:      sqlEngine.URI(dbAddress, dbPort, dbName, dbUsername, dbPassword),
-		JDBCURI:  sqlEngine.JDBCURI(dbAddress, dbPort, dbName, dbUsername, dbPassword),
+		Host:            dbAddress,
+		Port:            dbPort,
+		Name:            dbName,
+		Username:        dbUsername,
+		Password:        dbPassword,
+		URI:             sqlEngine.URI(dbAddress, dbPort, dbName, dbUsername, dbPassword),
+		JDBCURI:         sqlEngine.JDBCURI(dbAddress, dbPort, dbName, dbUsername, dbPassword),
+		Replicas:        dbInstanceDetails.ReadReplicaIds,
+		ReplicaURIs:     replicaURIs,
+		ReplicaJDBCURIs: replicaJDBCURIs,
 	}
 
 	return bindingResponse, nil

--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -30,6 +30,7 @@ const dbInstanceDetailsLogKey = "dbInstanceDetails"
 
 var (
 	ErrEncryptionNotUpdateable = errors.New("intance can not be updated to a plan with different encryption settings")
+	ErrReadReplicaNotAllowed   = errors.New("plan does not allow read replicas")
 )
 
 var rdsStatus2State = map[string]string{

--- a/rdsbroker/broker_test.go
+++ b/rdsbroker/broker_test.go
@@ -102,6 +102,7 @@ var _ = Describe("RDS Broker", func() {
 			EngineVersion:     "4.5.6",
 			AllocatedStorage:  300,
 			SkipFinalSnapshot: false,
+			AllowReadReplicas: true,
 		}
 	})
 
@@ -1184,6 +1185,25 @@ var _ = Describe("RDS Broker", func() {
 					Expect(err).To(HaveOccurred())
 					Expect(err).To(Equal(brokerapi.ErrInstanceDoesNotExist))
 				})
+			})
+		})
+
+		Context("when read replicas are not allowed", func() {
+			It("returns an error if replicas requested", func() {
+				updateDetails.Parameters["read_replica_count"] = 2
+				_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(Equal(ErrReadReplicaNotAllowed))
+			})
+		})
+
+		Context("when read replicas are allowed", func() {
+			It("returns an error if replicas requested", func() {
+				updateDetails.ServiceID = "Service-3"
+				updateDetails.PlanID = "Plan-3"
+				updateDetails.Parameters["read_replica_count"] = 2
+				_, err := rdsBroker.Update(instanceID, updateDetails, acceptsIncomplete)
+				Expect(err).NotTo(HaveOccurred())
 			})
 		})
 	})

--- a/rdsbroker/catalog.go
+++ b/rdsbroker/catalog.go
@@ -86,6 +86,7 @@ type RDSProperties struct {
 	VpcSecurityGroupIds        []string `json:"vpc_security_group_ids,omitempty"`
 	CopyTagsToSnapshot         bool     `json:"copy_tags_to_snapshot,omitempty"`
 	SkipFinalSnapshot          bool     `json:"skip_final_snapshot,omitempty"`
+	AllowReadReplicas          bool     `json:"allow_read_replicas,omitempty"`
 }
 
 func (c Catalog) Validate() error {

--- a/rdsbroker/parameters.go
+++ b/rdsbroker/parameters.go
@@ -44,7 +44,7 @@ func (pp *UpdateParameters) Validate(rp RDSProperties) error {
 		return err
 	}
 	if pp.ReadReplicaCount > 0 && !rp.AllowReadReplicas {
-		return errors.New("plan does not allow read replicas")
+		return ErrReadReplicaNotAllowed
 	}
 	return nil
 }

--- a/rdsbroker/parameters.go
+++ b/rdsbroker/parameters.go
@@ -39,6 +39,12 @@ func (pp *ProvisionParameters) Validate() error {
 	return Validate_SkipFinalSnapshot(pp.SkipFinalSnapshot)
 }
 
-func (pp *UpdateParameters) Validate() error {
-	return Validate_SkipFinalSnapshot(pp.SkipFinalSnapshot)
+func (pp *UpdateParameters) Validate(rp RDSProperties) error {
+	if err := Validate_SkipFinalSnapshot(pp.SkipFinalSnapshot); err != nil {
+		return err
+	}
+	if pp.ReadReplicaCount > 0 && !rp.AllowReadReplicas {
+		return errors.New("plan does not allow read replicas")
+	}
+	return nil
 }

--- a/rdsbroker/parameters.go
+++ b/rdsbroker/parameters.go
@@ -19,6 +19,7 @@ type UpdateParameters struct {
 	PreferredBackupWindow      string
 	PreferredMaintenanceWindow string
 	SkipFinalSnapshot          string `mapstructure:"skip_final_snapshot"`
+	ReadReplicaCount           int    `mapstructure:"read_replica_count"`
 }
 
 type BindParameters struct {


### PR DESCRIPTION
Some of our users need rds read replicas. This is the start of a feature that allows users to provision replicas on service update, like this:

`cf update-service my-service -c '{"read_replica_count": 2}'`

Tasks:
* [x] Create and destroy read replicas on update
* [x] Expose replicas in bind credentials
* [x] Mark instances as pending when replica scaling is in progress
* [x] Allow plans to allow or disallow replicas
* [ ] Validate number of replicas
* [ ] Only allow replicas on plans with backups enabled
* [ ] Test everything

pairing with @sharms