### PR TITLE
[#136725001] Do not allow update encryption settings

### DIFF
--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -2,6 +2,7 @@ package rdsbroker
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -26,6 +27,10 @@ const acceptsIncompleteLogKey = "acceptsIncomplete"
 const updateParametersLogKey = "updateParameters"
 const servicePlanLogKey = "servicePlan"
 const dbInstanceDetailsLogKey = "dbInstanceDetails"
+
+var (
+	ErrEncryptionNotUpdateable = errors.New("intance can not be updated to a plan with different encryption settings")
+)
 
 var rdsStatus2State = map[string]string{
 	"available":                    brokerapi.LastOperationSucceeded,
@@ -148,7 +153,7 @@ func (b *RDSBroker) Update(instanceID string, details brokerapi.UpdateDetails, a
 		if err := updateParameters.Validate(); err != nil {
 			return false, err
 		}
-		b.logger.Debug("update-parsed-params", lager.Data{updateParametersLogKey: updateParameters,})
+		b.logger.Debug("update-parsed-params", lager.Data{updateParametersLogKey: updateParameters})
 	}
 
 	service, ok := b.catalog.FindService(details.ServiceID)
@@ -163,6 +168,19 @@ func (b *RDSBroker) Update(instanceID string, details brokerapi.UpdateDetails, a
 	servicePlan, ok := b.catalog.FindServicePlan(details.PlanID)
 	if !ok {
 		return false, fmt.Errorf("Service Plan '%s' not found", details.PlanID)
+	}
+
+	previousServicePlan, ok := b.catalog.FindServicePlan(details.PreviousValues.PlanID)
+	if !ok {
+		return false, fmt.Errorf("Service Plan '%s' not found", details.PreviousValues.PlanID)
+	}
+
+	if servicePlan.RDSProperties.StorageEncrypted != previousServicePlan.RDSProperties.StorageEncrypted {
+		return false, ErrEncryptionNotUpdateable
+	}
+
+	if servicePlan.RDSProperties.KmsKeyID != previousServicePlan.RDSProperties.KmsKeyID {
+		return false, ErrEncryptionNotUpdateable
 	}
 
 	modifyDBInstance := b.modifyDBInstance(instanceID, servicePlan, updateParameters, details)


### PR DESCRIPTION
[#136725001 Enable at rest encryption for broker created RDS DB instances](https://www.pivotaltracker.com/n/projects/1275640/stories/136725001)

What
----

AWS RDS Storage Encryption[1] can only be set during creation of the RDS instance. In consequence, it would be erronous and misleading to allow update an instance to a plan that has different Storage Encryption settings  (enabled/disabled or KMS Key ID).

We add logic to fail noisily to inform the user about the imposibility of change encryption settings.

There were already tests to ensure that the parameters are passed during creation

[1] http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.Encryption.html


Dependencies
------
Broker release PR https://github.com/alphagov/paas-rds-broker-boshrelease/pull/28

How to review?
-------------

Code review. Tests should pass.

Who?
----

Anyone but @keymon