### PR TITLE
[#139361587]  Fail restore_snapshot if they provide empty string

### DIFF
--- a/rdsbroker/broker_test.go
+++ b/rdsbroker/broker_test.go
@@ -407,6 +407,17 @@ var _ = Describe("RDS Broker", func() {
 				})
 			})
 
+			Context("and the restore_from_latest_snapshot_of is an empty string", func() {
+				BeforeEach(func() {
+					provisionDetails.Parameters = map[string]interface{}{"restore_from_latest_snapshot_of": ""}
+				})
+				It("returns the correct error", func() {
+					_, _, err := rdsBroker.Provision(instanceID, provisionDetails, acceptsIncomplete)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).Should(ContainSubstring("Invalid guid"))
+				})
+			})
+
 		})
 
 		Context("when creating a new service instance", func() {

--- a/rdsbroker/parameters.go
+++ b/rdsbroker/parameters.go
@@ -10,8 +10,8 @@ type ProvisionParameters struct {
 	DBName                      string
 	PreferredBackupWindow       string
 	PreferredMaintenanceWindow  string
-	SkipFinalSnapshot           string `mapstructure:"skip_final_snapshot"`
-	RestoreFromLatestSnapshotOf string `mapstructure:"restore_from_latest_snapshot_of"`
+	SkipFinalSnapshot           string  `mapstructure:"skip_final_snapshot"`
+	RestoreFromLatestSnapshotOf *string `mapstructure:"restore_from_latest_snapshot_of"`
 }
 
 type UpdateParameters struct {


### PR DESCRIPTION
[#139361587 rds-broker: Able to create a instance from the latest snapshot of other instance](https://www.pivotaltracker.com/n/projects/1275640/stories/139361587)

What?
----

We merged #35, but it had a small bug. When passing a empty string with `restore_from_latest_snapshot_of` it will simply create an instance.

This PR makes it fail if the user passes `-c { "restore_from_latest_snapshot_of": ""}`

How to review?
--------------

Code review.

Follow the steps in #35. Test passing the parameters as above.

Who?
----

Anynoe but @keymon