### PR TITLE
[#139361587] Remove spurios call to PostRestoreTasks in Binding

### DIFF
--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -315,11 +315,6 @@ func (b *RDSBroker) Bind(instanceID, bindingID string, details brokerapi.BindDet
 		return bindingResponse, err
 	}
 
-	_, err = b.PostRestoreTasks(instanceID, &dbInstanceDetails)
-	if err != nil {
-		return bindingResponse, err
-	}
-
 	dbAddress := dbInstanceDetails.Address
 	dbPort := dbInstanceDetails.Port
 	masterUsername := dbInstanceDetails.MasterUsername


### PR DESCRIPTION
[#139361587 rds-broker: Able to create a instance from the latest snapshot of other instance](https://www.pivotaltracker.com/n/projects/1275640/stories/139361587)

What?
----

Binding is calling the method PostRestoreTasks(). It was added likely during the implementation of that feature accidentally: the original idea was to implement it in the Binding, but later was moved to LastOperation.

Calling this function in Binding is a no-op because all the work is always previously done in LastOperation.

There are also no tests around this call in Binding.

How to test?
-----------

Code review should be enough. Unit tests should pass.

Who?
----

Anyone but @keymon