### PR TITLE
[#139361587] Use SnapshotCreateTime to know snapshot age

### DIFF
--- a/awsrds/rds_db_instance.go
+++ b/awsrds/rds_db_instance.go
@@ -283,7 +283,7 @@ func (r *RDSDBInstance) buildDBSnapshot(dbSnapshot *rds.DBSnapshot) DBSnapshotDe
 	dbSnapshotDetails := DBSnapshotDetails{
 		Identifier:         aws.StringValue(dbSnapshot.DBSnapshotIdentifier),
 		InstanceIdentifier: aws.StringValue(dbSnapshot.DBInstanceIdentifier),
-		CreateTime:         aws.TimeValue(dbSnapshot.InstanceCreateTime),
+		CreateTime:         aws.TimeValue(dbSnapshot.SnapshotCreateTime),
 	}
 	return dbSnapshotDetails
 }

--- a/awsrds/rds_db_instance_test.go
+++ b/awsrds/rds_db_instance_test.go
@@ -508,7 +508,7 @@ var _ = Describe("RDS DB Instance", func() {
 						DBInstanceIdentifier: aws.String(instanceID),
 						DBSnapshotIdentifier: aws.String(instanceID + suffix),
 						DBSnapshotArn:        aws.String(dbSnapshotArn + suffix),
-						InstanceCreateTime:   aws.Time(instanceCreateTime),
+						SnapshotCreateTime:   aws.Time(instanceCreateTime),
 					}
 				}
 


### PR DESCRIPTION
[#139361587 rds-broker: Able to create a instance from the latest snapshot of other instance](https://www.pivotaltracker.com/story/show/139361587)

What?
----

We were using the wrong field to short the snapshots of an instance. We   should use `SnapshotCreateTime`, not `InstanceCreateTime` that is the date of the creation of the instance.

Because this, we are actually restoring the oldest because AWS API seems to return ordered by from oldest to newest.

Related
--------

After merge this, update, remove the WIP and merge: https://github.com/alphagov/paas-rds-broker-boshrelease/pull/34  https://github.com/alphagov/paas-cf/pull/816  

How to review?
------------

Code review.

You can review following the steps described in https://github.com/alphagov/paas-cf/pull/784, but creating 2x snapshots instead of one.

Then check that the Tag "Restored Snapshot From" of the restored instance is the latest snapshot.

Who?
---

Anyone but @keymon