### PR TITLE
[#142122527] Fix bind and update without custom parameters

### DIFF
--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -207,7 +207,7 @@ func (b *RDSBroker) Update(
 	}
 
 	updateParameters := UpdateParameters{}
-	if b.allowUserUpdateParameters {
+	if b.allowUserUpdateParameters && len(details.RawParameters) > 0 {
 		if err := json.Unmarshal(details.RawParameters, &updateParameters); err != nil {
 			return brokerapi.UpdateServiceSpec{}, err
 		}
@@ -314,7 +314,7 @@ func (b *RDSBroker) Bind(
 	bindingResponse := brokerapi.Binding{}
 
 	bindParameters := BindParameters{}
-	if b.allowUserBindParameters {
+	if b.allowUserBindParameters && len(details.RawParameters) > 0 {
 		if err := json.Unmarshal(details.RawParameters, &bindParameters); err != nil {
 			return bindingResponse, err
 		}

--- a/rdsbroker/broker_test.go
+++ b/rdsbroker/broker_test.go
@@ -312,12 +312,41 @@ var _ = Describe("RDS Broker", func() {
 				PlanID:           "Plan-1",
 				ServiceID:        "Service-1",
 				SpaceGUID:        "space-id",
+				RawParameters:    json.RawMessage{},
 			}
 			acceptsIncomplete = true
 
 			properProvisionedServiceSpec = brokerapi.ProvisionedServiceSpec{
 				IsAsync: true,
 			}
+		})
+
+		Context("when custom parameters are not provided", func() {
+			BeforeEach(func() {
+				allowUserProvisionParameters = true
+			})
+
+			Context("when not present in request", func() {
+				BeforeEach(func() {
+					provisionDetails.RawParameters = nil
+				})
+
+				It("does not return an error", func() {
+					_, err := rdsBroker.Provision(ctx, instanceID, provisionDetails, acceptsIncomplete)
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+
+			Context("when an empty JSON document", func() {
+				BeforeEach(func() {
+					provisionDetails.RawParameters = json.RawMessage("{}")
+				})
+
+				It("does not return an error", func() {
+					_, err := rdsBroker.Provision(ctx, instanceID, provisionDetails, acceptsIncomplete)
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
 		})
 
 		It("returns the proper response", func() {
@@ -981,7 +1010,7 @@ var _ = Describe("RDS Broker", func() {
 					OrgID:     "organization-id",
 					SpaceID:   "space-id",
 				},
-				RawParameters: json.RawMessage("{}"),
+				RawParameters: json.RawMessage{},
 			}
 			acceptsIncomplete = true
 			properUpdateServiceSpec = brokerapi.UpdateServiceSpec{
@@ -1013,6 +1042,34 @@ var _ = Describe("RDS Broker", func() {
 			Expect(dbInstance.ModifyDBInstanceDetails.Tags["Service ID"]).To(Equal("Service-2"))
 			Expect(dbInstance.ModifyDBInstanceDetails.Tags["Plan ID"]).To(Equal("Plan-2"))
 			Expect(err).ToNot(HaveOccurred())
+		})
+
+		Context("when custom parameters are not provided", func() {
+			BeforeEach(func() {
+				allowUserUpdateParameters = true
+			})
+
+			Context("when not present in request", func() {
+				BeforeEach(func() {
+					updateDetails.RawParameters = nil
+				})
+
+				It("does not return an error", func() {
+					_, err := rdsBroker.Update(ctx, instanceID, updateDetails, acceptsIncomplete)
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+
+			Context("when an empty JSON document", func() {
+				BeforeEach(func() {
+					updateDetails.RawParameters = json.RawMessage("{}")
+				})
+
+				It("does not return an error", func() {
+					_, err := rdsBroker.Update(ctx, instanceID, updateDetails, acceptsIncomplete)
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
 		})
 
 		Context("when has AllocatedStorage", func() {
@@ -1537,7 +1594,7 @@ var _ = Describe("RDS Broker", func() {
 				ServiceID:     "Service-1",
 				PlanID:        "Plan-1",
 				AppGUID:       "Application-1",
-				RawParameters: json.RawMessage("{}"),
+				RawParameters: json.RawMessage{},
 			}
 
 			dbInstance.DescribeDBInstanceDetails = awsrds.DBInstanceDetails{
@@ -1647,6 +1704,34 @@ var _ = Describe("RDS Broker", func() {
 
 			Expect(recorder.Code).To(Equal(201))
 
+		})
+
+		Context("when not using custom parameters", func() {
+			BeforeEach(func() {
+				allowUserBindParameters = true
+			})
+
+			Context("when absent from the request", func() {
+				BeforeEach(func() {
+					bindDetails.RawParameters = nil
+				})
+
+				It("does not return an error", func() {
+					_, err := rdsBroker.Bind(ctx, instanceID, bindingID, bindDetails)
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+
+			Context("when present as an empty JSON document", func() {
+				BeforeEach(func() {
+					bindDetails.RawParameters = json.RawMessage("{}")
+				})
+
+				It("does not return an error", func() {
+					_, err := rdsBroker.Bind(ctx, instanceID, bindingID, bindDetails)
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
 		})
 
 		// FIXME: Re-enable these tests when we have some bind-time parameters again


### PR DESCRIPTION
## What

A tenant reported that the `cf update-service` command didn't work. I was
able to reproduce it on my development environment:

    ➜  paas-cf git:(master) ✗ cf create-service postgres M-HA-dedicated-9.5 dcarley-test
    …
    ➜  paas-cf git:(master) ✗ cf update-service dcarley-test -p L-HA-dedicated-9.5
    Updating service instance dcarley-test as admin...
    FAILED
    Server error, status code: 502, error code: 10001, message: Service broker error: unexpected end of JSON input

The error occurs when no custom parameters are passed. You can workaround it
by supplying *any* custom parameters e.g. `-c '{"pretty_please":true}'`.
However `-c '{}'` isn't sufficient because the CLI unmarshalls it to an
empty map and then remarshalls the parameters into the request with
`omitempty`.

This worked prior to the dependency updates in 0ac81ce because
`frodenas/brokerapi.UpdateDetails.Parameters` was `map[string]interface{}`
`mapstructure.Decode()` on an empty map was a noop.

The fix is to check whether the parameters are zero-length before attempting
to unmarshall them. We already do this for provision/create-service. It
turned out that bind/bind-service also had the same bug, but we don't deploy
the broker with `rdsbroker.Config.AllowUserBindParameters = true` so the
params are never unmarshalled and we haven't yet been affected.

I've added new unit tests to call out this behaviour for `nil` and `{}`
custom parameters. I'm explicitly setting the "allow" parameter in each
context because I want to ensure that we enter the conditional if we change
the global default for the tests. I considered adding integration tests too,
but I'm not convinced that they would be any clearer or more effective,
since we're interacting with the broker API and quite far removed from what
the CLI or CF may or may not provide us.

It's worth noting that the use of `len(p) > 0` is preferable to `p != nil`
because it works for both an uninitialised field of `json.RawMessage{nil}`
as well as an initialised but empty field of `json.RawMessage{}` or
`json.RawMessage("")`. I don't think they all warrant separate unit tests
though, so I've made one of the second cases the default for all other test
contexts.

## How to review

My feeling is that a code review and ensuring the tests pass will be sufficient.

You can use alphagov/paas-cf#841 and alphagov/paas-rds-broker-boshrelease#35 to test it. You can repeat the commands I used above to verify that it works, although it takes quite a long time to create and update RDS. You'll need to update and review those PRs afterwards.

## Who can review

Not @dcarley