### PR TITLE
[#140847887] Remove "production ready" disclaimer from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,9 @@ This is a fork of [AWS RDS Service Broker](https://github.com/cf-platform-eng/rd
 
 We have changed all source code includes to point to this repository.
 
-This is an **experimental** [Cloud Foundry Service Broker](https://docs.cloudfoundry.org/services/overview.html) for [Amazon Relational Database Service (RDS)](https://aws.amazon.com/rds/) supporting [MariaDB](https://aws.amazon.com/rds/mariadb/), [MySQL](https://aws.amazon.com/rds/mysql/) and [PostgreSQL](https://aws.amazon.com/rds/postgresql/) RDS Databases.
+This is a [Cloud Foundry Service Broker](https://docs.cloudfoundry.org/services/overview.html) for [Amazon Relational Database Service (RDS)](https://aws.amazon.com/rds/) supporting [MariaDB](https://aws.amazon.com/rds/mariadb/), [MySQL](https://aws.amazon.com/rds/mysql/) and [PostgreSQL](https://aws.amazon.com/rds/postgresql/) RDS Databases.
 
 More details can be found at this [Pivotal P.O.V Blog post](http://blog.pivotal.io/pivotal-cloud-foundry/products/a-look-at-cloud-foundrys-service-broker-updates).
-
-## Disclaimer
-
-This is **NOT** presently a production ready Service Broker. This is a work in progress. It is suitable for experimentation and may not become supported in the future.
 
 ## Installation
 


### PR DESCRIPTION
## What

This was carried over from the original Pivotal code that we forked. We have
since been using this broker in production, so the disclaimer about it being
experimental and not production ready is no longer accurate.

## How to review

Confirm that the text changes make sense.

## Who can review

Anyone