### PR TITLE
[#140849465] Add tests taken from paas-cf custom acceptance tests

### DIFF
--- a/ci/helpers/brokerapi_helper.go
+++ b/ci/helpers/brokerapi_helper.go
@@ -289,6 +289,7 @@ func (b *BrokerAPIClient) DoBindRequest(instanceID, serviceID, planID, appGUID, 
 		}`,
 		serviceID,
 		planID,
+		appGUID,
 	))
 
 	return b.doRequest(

--- a/ci/helpers/brokerapi_helper.go
+++ b/ci/helpers/brokerapi_helper.go
@@ -297,3 +297,15 @@ func (b *BrokerAPIClient) DoBindRequest(instanceID, serviceID, planID, appGUID, 
 		bytes.NewBuffer(bindingDetailsJson),
 	)
 }
+
+func (b *BrokerAPIClient) DoUnbindRequest(instanceID, serviceID, planID, bindingID string) (*http.Response, error) {
+	path := fmt.Sprintf("/v2/service_instances/%s/service_bindings/%s", instanceID, bindingID)
+
+	return b.doRequest(
+		"DELETE",
+		path,
+		nil,
+		uriParam{key: "service_id", value: serviceID},
+		uriParam{key: "plan_id", value: planID},
+	)
+}


### PR DESCRIPTION
## What

https://www.pivotaltracker.com/story/show/140849465

These tests were present in the paas-cf repository[1], but have been moved here because we want this repository to have tests for integrating the broker with the AWS API, and we want paas-cf to only test those integrations which demonstrate the broker works when deployed in our Cloud Foundry environment. This should produce a faster paas-cf deployment and enables full integration testing without having to deploy the broker with Cloud Foundry.

Moving these tests here may mean some commit history is lost, so I shall re-iterate why they were added initially: we have changed the way Postgres users are created in the past, and we will be changing it again to make use of event triggers to transfer the object permissions. Therefore, we need confidence the user created with a bind has full permissions over the objecs created by users from previous binds.

## How to review

Review in conjunction with https://github.com/alphagov/paas-cf/pull/951, because the idea of the story is to have all of the same tests, but split across the two repositories. Therefore, we want to ensure no tests have been lost in the process.

* Code review. You can add `?w=1` to the URL in the browser when viewing the files changed in this pull request, this will remove purely whitespace changes (resulting from `GoFmt` indendation).
* Run the tests in the ci build environment. Unfortunately the easiest way to do this is to do a no-op rebase and force push to this branch, then the pull request resource in Concourse will pick up the new version and trigger the job.

## Who

Anyone but me or @paroxp 