### PR TITLE
README: Use docker containers for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,20 +119,19 @@ To run the tests of this broker, you need a Postgres and MySQL running locally, 
 
 In travis we use the [postgres service](https://docs.travis-ci.com/user/database-setup/#PostgreSQL) and the [mysql service](https://docs.travis-ci.com/user/database-setup/#MySQL)
 
-You can run locally a postgres docker container and a homebrew-installed MySQL to run the tests
+Locally you can use containers with [Docker for Mac](https://docs.docker.com/docker-for-mac/) or [Docker for Linux](https://docs.docker.com/engine/installation/linux/ubuntu/):
 
 ```
 docker run -p 5432:5432 --name postgres -e POSTGRES_PASSWORD= -d postgres
-export POSTGRESQL_HOSTNAME=${DOCKER_HOSTNAME:-localhost} # Change accordingly
 
-brew install mysql
-mysql.server start
+docker run -p 3306:3306 --name mysql -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -d mysql
+until docker exec mysql mysqladmin ping --silent; do
+  printf "."; sleep 1
+done
 
 make unit
 
-docker stop postgres
-docker rm postgres
-mysql.server stop
+docker rm -f postgres mysql
 ```
 
 ### Running the integration tests

--- a/README.md
+++ b/README.md
@@ -122,9 +122,9 @@ In travis we use the [postgres service](https://docs.travis-ci.com/user/database
 Locally you can use containers with [Docker for Mac](https://docs.docker.com/docker-for-mac/) or [Docker for Linux](https://docs.docker.com/engine/installation/linux/ubuntu/):
 
 ```
-docker run -p 5432:5432 --name postgres -e POSTGRES_PASSWORD= -d postgres
+docker run -p 5432:5432 --name postgres -e POSTGRES_PASSWORD= -d postgres:9.5
 
-docker run -p 3306:3306 --name mysql -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -d mysql
+docker run -p 3306:3306 --name mysql -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -d mysql:5.7
 until docker exec mysql mysqladmin ping --silent; do
   printf "."; sleep 1
 done

--- a/README.md
+++ b/README.md
@@ -115,15 +115,9 @@ There are two forms of tests for the broker, the unit tests and the integration 
 
 ### Running the unit tests
 
-To run the tests of this broker, you need a postgres and MySQL running locally, without SSL.
+To run the tests of this broker, you need a Postgres and MySQL running locally, without SSL. The connection details can be configured using environment variables - see the `sqlengine` test suites for more information.
 
 In travis we use the [postgres service](https://docs.travis-ci.com/user/database-setup/#PostgreSQL) and the [mysql service](https://docs.travis-ci.com/user/database-setup/#MySQL)
-
-The tests can read from environment variables the server configuration, with the following defaults:
- * `POSTGRESQL_HOSTNAME=localhost`
- * `POSTGRESQL_PORT=5432`
- * `POSTGRESQL_USERNAME=postgres`
- * `POSTGRESQL_PASSWORD=`
 
 You can run locally a postgres docker container and a homebrew-installed MySQL to run the tests
 


### PR DESCRIPTION
## What

I think this is preferable to using Homebrew because it:

- doesn't pollute my main machine with necessary dependencies
- is consistent with our documentation for Postgres

I had to tweak the instructions for getting the IP address of the Docker
host. For now we can assume that everyone is using Docker Machine, but they
will need to use the appropriate name of their VM.

Also the containers can be stopped and deleted in one command.

## How to review

Follow the instructions in the README and check whether it works for you.

## Who can review

Anyone