### PR TITLE
[#147010925] Specify only major engine versions in integration tests

### DIFF
--- a/ci/blackbox/config.json
+++ b/ci/blackbox/config.json
@@ -25,7 +25,7 @@
                      "db_instance_class" : "db.t2.micro",
                      "allocated_storage" : 10,
                      "skip_final_snapshot" : true,
-                     "engine_version" : "9.5.4",
+                     "engine_version" : "9.5",
                      "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
                      "vpc_security_group_ids": ["POPULATED_BY_TEST_SUITE"]
                   },
@@ -41,7 +41,7 @@
                {
                   "name" : "Plan 2",
                   "rds_properties" : {
-                     "engine_version" : "9.5.4",
+                     "engine_version" : "9.5",
                      "skip_final_snapshot" : false,
                      "allocated_storage" : 20,
                      "engine" : "postgres",
@@ -66,7 +66,7 @@
                      "allocated_storage" : 30,
                      "engine" : "postgres",
                      "db_instance_class" : "db.t2.small",
-                     "engine_version" : "9.5.4",
+                     "engine_version" : "9.5",
                      "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
                      "vpc_security_group_ids": ["POPULATED_BY_TEST_SUITE"]
                   },
@@ -88,7 +88,7 @@
                 "allocated_storage" : 30,
                 "engine" : "mysql",
                 "db_instance_class" : "db.t2.small",
-                "engine_version" : "5.7.17",
+                "engine_version" : "5.7",
                 "db_subnet_group_name": "DB_SUBNET_GROUP_NAME",
                 "vpc_security_group_ids": ["VPC_SECURITY_GROUP_ID"]
               },
@@ -110,7 +110,7 @@
                 "allocated_storage" : 30,
                 "engine" : "mysql",
                 "db_instance_class" : "db.t2.small",
-                "engine_version" : "5.7.17",
+                "engine_version" : "5.7",
                 "db_subnet_group_name": "DB_SUBNET_GROUP_NAME",
                 "vpc_security_group_ids": ["VPC_SECURITY_GROUP_ID"]
               },


### PR DESCRIPTION
## What

We're making a change in paas-cf (https://github.com/alphagov/paas-cf/pull/955) to only pin the major version in the catalog. This therefore updates the integration tests to do the same.

## How to review

* Code review
* Verify the integration tests pass.

## Who can review

Not me.