### PR TITLE
Test connection with new user

### DIFF
--- a/sqlengine/mysql_engine_test.go
+++ b/sqlengine/mysql_engine_test.go
@@ -108,6 +108,11 @@ var _ = Describe("MySQLEngine", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(createdUser).NotTo(BeEmpty())
 			Expect(createdPassword).NotTo(BeEmpty())
+
+			By("should connect to the DB with createdUser")
+
+			err = mysqlEngine.Open(address, port, dbname, createdUser, createdPassword)
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("DropUser() should drop the user successfully", func() {


### PR DESCRIPTION
## What

At the moment, the user and password created, are not tested when
establishing the connection. To prevent issues down the line, we'd like
to cover that case with some tests.

It has pointed out the issues in our code, where we didn't use back
ticks to identify the database in a query related to GRANT.

It is caused, by the fact that not all characters we are generating,
particularly the hyphen, are not acceptable in an unquoted identifier.

Ref: https://dev.mysql.com/doc/refman/5.5/en/identifiers.html

## How to review

- Code review
- Run MySQL (and postgres optionally) services locally - or rely on travis being happy
- Execute `make unit` and see mysql test pass

## Who can review

Not @LeePorte nor @paroxp