### PR TITLE
[#147829023] Improve integration tests for MySQL

### DIFF
--- a/ci/blackbox/config.json
+++ b/ci/blackbox/config.json
@@ -1,131 +1,141 @@
 {
-  "log_level": "DEBUG",
-  "username": "username",
-  "password": "password",
-  "state_encryption_key": "key",
-  "rds_config": {
-    "region": "eu-west-1",
-    "db_prefix": "build-test",
-    "allow_user_provision_parameters": true,
-    "allow_user_update_parameters": true,
-    "allow_user_bind_parameters": true,
-    "master_password_seed": "something-secret",
-    "broker_name": "rdsbroker-integration-test",
-    "catalog" : {
-      "services" : [
-         {
-            "id" : "Service-1",
-            "description" : "This is the Service 1",
-            "name" : "Service 1",
-            "plan_updateable" : true,
-            "plans" : [
-               {
-                  "rds_properties" : {
-                     "engine" : "postgres",
-                     "db_instance_class" : "db.t2.micro",
-                     "allocated_storage" : 10,
-                     "skip_final_snapshot" : true,
-                     "engine_version" : "9.5",
-                     "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
-                     "vpc_security_group_ids": ["POPULATED_BY_TEST_SUITE"]
-                  },
-                  "free" : false,
-                  "name" : "Plan 1",
-                  "description" : "This is the Plan 1",
-                  "id" : "Plan-1"
-               }
+    "log_level": "DEBUG",
+    "password": "password",
+    "rds_config": {
+        "allow_user_bind_parameters": true,
+        "allow_user_provision_parameters": true,
+        "allow_user_update_parameters": true,
+        "broker_name": "rdsbroker-integration-test",
+        "catalog": {
+            "services": [
+                {
+                    "description": "This is the Service 1",
+                    "id": "Service-1",
+                    "name": "Service 1",
+                    "plan_updateable": true,
+                    "plans": [
+                        {
+                            "description": "This is the Plan 1",
+                            "free": false,
+                            "id": "Plan-1",
+                            "name": "Plan 1",
+                            "rds_properties": {
+                                "allocated_storage": 10,
+                                "db_instance_class": "db.t2.micro",
+                                "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
+                                "engine": "postgres",
+                                "engine_version": "9.5",
+                                "skip_final_snapshot": true,
+                                "vpc_security_group_ids": [
+                                    "POPULATED_BY_TEST_SUITE"
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "description": "This is the Service 2",
+                    "id": "Service-2",
+                    "name": "Service 2",
+                    "plan_updateable": true,
+                    "plans": [
+                        {
+                            "description": "This is the Plan 2",
+                            "free": false,
+                            "id": "Plan-2",
+                            "name": "Plan 2",
+                            "rds_properties": {
+                                "allocated_storage": 20,
+                                "db_instance_class": "db.t2.small",
+                                "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
+                                "engine": "postgres",
+                                "engine_version": "9.5",
+                                "skip_final_snapshot": false,
+                                "vpc_security_group_ids": [
+                                    "POPULATED_BY_TEST_SUITE"
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "description": "This is the Service 3",
+                    "id": "Service-3",
+                    "name": "Service 3",
+                    "plan_updateable": true,
+                    "plans": [
+                        {
+                            "description": "This is the Plan 3",
+                            "free": false,
+                            "id": "Plan-3",
+                            "name": "Plan 3",
+                            "rds_properties": {
+                                "allocated_storage": 30,
+                                "db_instance_class": "db.t2.small",
+                                "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
+                                "engine": "postgres",
+                                "engine_version": "9.5",
+                                "vpc_security_group_ids": [
+                                    "POPULATED_BY_TEST_SUITE"
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "description": "This is the Service 4",
+                    "id": "Service-4",
+                    "name": "Service 4",
+                    "plan_updateable": true,
+                    "plans": [
+                        {
+                            "description": "This is the Plan 4",
+                            "free": false,
+                            "id": "Plan-4",
+                            "name": "Plan 4",
+                            "rds_properties": {
+                                "allocated_storage": 30,
+                                "db_instance_class": "db.t2.small",
+                                "db_subnet_group_name": "DB_SUBNET_GROUP_NAME",
+                                "engine": "mysql",
+                                "engine_version": "5.7",
+                                "vpc_security_group_ids": [
+                                    "VPC_SECURITY_GROUP_ID"
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "description": "This is the Service 5",
+                    "id": "Service-5",
+                    "name": "Service 5",
+                    "plan_updateable": true,
+                    "plans": [
+                        {
+                            "description": "This is the Plan 5",
+                            "free": false,
+                            "id": "Plan-5",
+                            "name": "Plan 5",
+                            "rds_properties": {
+                                "allocated_storage": 30,
+                                "db_instance_class": "db.t2.small",
+                                "db_subnet_group_name": "DB_SUBNET_GROUP_NAME",
+                                "engine": "mysql",
+                                "engine_version": "5.7",
+                                "vpc_security_group_ids": [
+                                    "VPC_SECURITY_GROUP_ID"
+                                ]
+                            }
+                        }
+                    ]
+                }
             ]
-         },
-         {
-            "plans" : [
-               {
-                  "name" : "Plan 2",
-                  "rds_properties" : {
-                     "engine_version" : "9.5",
-                     "skip_final_snapshot" : false,
-                     "allocated_storage" : 20,
-                     "engine" : "postgres",
-                     "db_instance_class" : "db.t2.small",
-                     "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
-                     "vpc_security_group_ids": ["POPULATED_BY_TEST_SUITE"]
-                  },
-                  "free" : false,
-                  "id" : "Plan-2",
-                  "description" : "This is the Plan 2"
-               }
-            ],
-            "plan_updateable" : true,
-            "name" : "Service 2",
-            "description" : "This is the Service 2",
-            "id" : "Service-2"
-         },
-         {
-            "plans" : [
-               {
-                  "rds_properties" : {
-                     "allocated_storage" : 30,
-                     "engine" : "postgres",
-                     "db_instance_class" : "db.t2.small",
-                     "engine_version" : "9.5",
-                     "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
-                     "vpc_security_group_ids": ["POPULATED_BY_TEST_SUITE"]
-                  },
-                  "free" : false,
-                  "name" : "Plan 3",
-                  "id" : "Plan-3",
-                  "description" : "This is the Plan 3"
-               }
-            ],
-            "name" : "Service 3",
-            "plan_updateable" : true,
-            "description" : "This is the Service 3",
-            "id" : "Service-3"
-         },
-        {
-          "plans" : [
-            {
-              "rds_properties" : {
-                "allocated_storage" : 30,
-                "engine" : "mysql",
-                "db_instance_class" : "db.t2.small",
-                "engine_version" : "5.7",
-                "db_subnet_group_name": "DB_SUBNET_GROUP_NAME",
-                "vpc_security_group_ids": ["VPC_SECURITY_GROUP_ID"]
-              },
-              "free" : false,
-              "name" : "Plan 4",
-              "id" : "Plan-4",
-              "description" : "This is the Plan 4"
-            }
-          ],
-          "name" : "Service 4",
-          "plan_updateable" : true,
-          "description" : "This is the Service 4",
-          "id" : "Service-4"
         },
-        {
-          "plans" : [
-            {
-              "rds_properties" : {
-                "allocated_storage" : 30,
-                "engine" : "mysql",
-                "db_instance_class" : "db.t2.small",
-                "engine_version" : "5.7",
-                "db_subnet_group_name": "DB_SUBNET_GROUP_NAME",
-                "vpc_security_group_ids": ["VPC_SECURITY_GROUP_ID"]
-              },
-              "free" : false,
-              "name" : "Plan 5",
-              "id" : "Plan-5",
-              "description" : "This is the Plan 5"
-            }
-          ],
-          "name" : "Service 5",
-          "plan_updateable" : true,
-          "description" : "This is the Service 5",
-          "id" : "Service-5"
-        }
-      ]
-    }
-  }
+        "db_prefix": "build-test",
+        "master_password_seed": "something-secret",
+        "region": "eu-west-1"
+    },
+    "state_encryption_key": "key",
+    "username": "username"
 }

--- a/ci/blackbox/config.json
+++ b/ci/blackbox/config.json
@@ -9,16 +9,32 @@
         "catalog": {
             "services": [
                 {
-                    "description": "This is the Service 1",
-                    "id": "Service-1",
-                    "name": "Service 1",
+                    "description": "AWS RDS PostgreSQL service",
+                    "id": "postgres",
+                    "name": "postgres",
                     "plan_updateable": true,
                     "plans": [
                         {
-                            "description": "This is the Plan 1",
+                            "description": "Micro plan",
                             "free": false,
-                            "id": "Plan-1",
-                            "name": "Plan 1",
+                            "id": "micro",
+                            "name": "micro",
+                            "rds_properties": {
+                                "allocated_storage": 10,
+                                "db_instance_class": "db.t2.micro",
+                                "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
+                                "engine": "postgres",
+                                "engine_version": "9.5",
+                                "vpc_security_group_ids": [
+                                    "POPULATED_BY_TEST_SUITE"
+                                ]
+                            }
+                        },
+                        {
+                            "description": "Micro plan without final snapshot",
+                            "free": false,
+                            "id": "micro-without-snapshot",
+                            "name": "micro-without-snapshot",
                             "rds_properties": {
                                 "allocated_storage": 10,
                                 "db_instance_class": "db.t2.micro",
@@ -34,97 +50,41 @@
                     ]
                 },
                 {
-                    "description": "This is the Service 2",
-                    "id": "Service-2",
-                    "name": "Service 2",
+                    "description": "AWS RDS MySQL service",
+                    "id": "mysql",
+                    "name": "mysql",
                     "plan_updateable": true,
                     "plans": [
                         {
-                            "description": "This is the Plan 2",
+                            "description": "Micro plan",
                             "free": false,
-                            "id": "Plan-2",
-                            "name": "Plan 2",
+                            "id": "micro",
+                            "name": "micro",
                             "rds_properties": {
-                                "allocated_storage": 20,
-                                "db_instance_class": "db.t2.small",
+                                "allocated_storage": 10,
+                                "db_instance_class": "db.t2.micro",
                                 "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
-                                "engine": "postgres",
-                                "engine_version": "9.5",
-                                "skip_final_snapshot": false,
+                                "engine": "mysql",
+                                "engine_version": "5.7",
                                 "vpc_security_group_ids": [
                                     "POPULATED_BY_TEST_SUITE"
                                 ]
                             }
-                        }
-                    ]
-                },
-                {
-                    "description": "This is the Service 3",
-                    "id": "Service-3",
-                    "name": "Service 3",
-                    "plan_updateable": true,
-                    "plans": [
+                        },
                         {
-                            "description": "This is the Plan 3",
+                            "description": "Micro plan without final snapshot",
                             "free": false,
-                            "id": "Plan-3",
-                            "name": "Plan 3",
+                            "id": "micro-without-snapshot",
+                            "name": "micro-without-snapshot",
                             "rds_properties": {
-                                "allocated_storage": 30,
-                                "db_instance_class": "db.t2.small",
+                                "allocated_storage": 10,
+                                "db_instance_class": "db.t2.micro",
                                 "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
-                                "engine": "postgres",
-                                "engine_version": "9.5",
+                                "engine": "mysql",
+                                "engine_version": "5.7",
+                                "skip_final_snapshot": true,
                                 "vpc_security_group_ids": [
                                     "POPULATED_BY_TEST_SUITE"
-                                ]
-                            }
-                        }
-                    ]
-                },
-                {
-                    "description": "This is the Service 4",
-                    "id": "Service-4",
-                    "name": "Service 4",
-                    "plan_updateable": true,
-                    "plans": [
-                        {
-                            "description": "This is the Plan 4",
-                            "free": false,
-                            "id": "Plan-4",
-                            "name": "Plan 4",
-                            "rds_properties": {
-                                "allocated_storage": 30,
-                                "db_instance_class": "db.t2.small",
-                                "db_subnet_group_name": "DB_SUBNET_GROUP_NAME",
-                                "engine": "mysql",
-                                "engine_version": "5.7",
-                                "vpc_security_group_ids": [
-                                    "VPC_SECURITY_GROUP_ID"
-                                ]
-                            }
-                        }
-                    ]
-                },
-                {
-                    "description": "This is the Service 5",
-                    "id": "Service-5",
-                    "name": "Service 5",
-                    "plan_updateable": true,
-                    "plans": [
-                        {
-                            "description": "This is the Plan 5",
-                            "free": false,
-                            "id": "Plan-5",
-                            "name": "Plan 5",
-                            "rds_properties": {
-                                "allocated_storage": 30,
-                                "db_instance_class": "db.t2.small",
-                                "db_subnet_group_name": "DB_SUBNET_GROUP_NAME",
-                                "engine": "mysql",
-                                "engine_version": "5.7",
-                                "vpc_security_group_ids": [
-                                    "VPC_SECURITY_GROUP_ID"
                                 ]
                             }
                         }

--- a/ci/blackbox/rdsbroker_test.go
+++ b/ci/blackbox/rdsbroker_test.go
@@ -39,41 +39,30 @@ var _ = Describe("RDS Broker Daemon", func() {
 
 			sort.Sort(ByServiceID(catalog.Services))
 
-			Expect(catalog.Services).To(HaveLen(5))
+			Expect(catalog.Services).To(HaveLen(2))
 			service1 := catalog.Services[0]
 			service2 := catalog.Services[1]
-			service3 := catalog.Services[2]
-			service4 := catalog.Services[3]
-			service5 := catalog.Services[4]
-			Expect(service1.ID).To(Equal("Service-1"))
-			Expect(service2.ID).To(Equal("Service-2"))
-			Expect(service3.ID).To(Equal("Service-3"))
-			Expect(service4.ID).To(Equal("Service-4"))
-			Expect(service5.ID).To(Equal("Service-5"))
 
-			Expect(service1.ID).To(Equal("Service-1"))
-			Expect(service1.Name).To(Equal("Service 1"))
-			Expect(service1.Description).To(Equal("This is the Service 1"))
+			Expect(service1.ID).To(Equal("mysql"))
+			Expect(service1.Name).To(Equal("mysql"))
+			Expect(service1.Description).To(Equal("AWS RDS MySQL service"))
 			Expect(service1.Bindable).To(BeTrue())
 			Expect(service1.PlanUpdatable).To(BeTrue())
-			Expect(service1.Plans).To(HaveLen(1))
-			Expect(service1.Plans[0].ID).To(Equal("Plan-1"))
-			Expect(service1.Plans[0].Name).To(Equal("Plan 1"))
-			Expect(service1.Plans[0].Description).To(Equal("This is the Plan 1"))
-			Expect(service5.ID).To(Equal("Service-5"))
-			Expect(service5.Name).To(Equal("Service 5"))
-			Expect(service5.Description).To(Equal("This is the Service 5"))
-			Expect(service5.Bindable).To(BeTrue())
-			Expect(service5.PlanUpdatable).To(BeTrue())
-			Expect(service5.Plans).To(HaveLen(1))
-			Expect(service5.Plans[0].ID).To(Equal("Plan-5"))
-			Expect(service5.Plans[0].Name).To(Equal("Plan 5"))
-			Expect(service5.Plans[0].Description).To(Equal("This is the Plan 5"))
+			Expect(service1.Plans).To(HaveLen(2))
+
+			Expect(service2.ID).To(Equal("postgres"))
+			Expect(service2.Name).To(Equal("postgres"))
+			Expect(service2.Description).To(Equal("AWS RDS PostgreSQL service"))
+			Expect(service2.Bindable).To(BeTrue())
+			Expect(service2.PlanUpdatable).To(BeTrue())
+			Expect(service2.Plans).To(HaveLen(2))
 		})
 	})
 
 	Describe("Instance Provision/Bind/Deprovision", func() {
-		TestProvisionBindDeprovision := func(serviceID, planID string) {
+		TestProvisionBindDeprovision := func(serviceID string) {
+			const planID = "micro-without-snapshot"
+
 			var (
 				instanceID string
 				appGUID    string
@@ -132,16 +121,18 @@ var _ = Describe("RDS Broker Daemon", func() {
 		}
 
 		Describe("Postgres", func() {
-			TestProvisionBindDeprovision("Service-1", "Plan-1")
+			TestProvisionBindDeprovision("postgres")
 		})
 
 		Describe("MySQL", func() {
-			TestProvisionBindDeprovision("Service-4", "Plan-4")
+			TestProvisionBindDeprovision("mysql")
 		})
 	})
 
 	Describe("Final snapshot enable/disable", func() {
-		TestFinalSnapshot := func(serviceID, planID string) {
+		TestFinalSnapshot := func(serviceID string) {
+			const planID = "micro"
+
 			var (
 				instanceID string
 				appGUID    string
@@ -238,11 +229,11 @@ var _ = Describe("RDS Broker Daemon", func() {
 		}
 
 		Describe("Postgres", func() {
-			TestFinalSnapshot("Service-2", "Plan-2")
+			TestFinalSnapshot("postgres")
 		})
 
 		Describe("MySQL", func() {
-			TestFinalSnapshot("Service-5", "Plan-5")
+			TestFinalSnapshot("mysql")
 		})
 	})
 })

--- a/ci/blackbox/rdsbroker_test.go
+++ b/ci/blackbox/rdsbroker_test.go
@@ -72,7 +72,7 @@ var _ = Describe("RDS Broker Daemon", func() {
 		})
 	})
 
-	Describe("Postgres Instance Provision/Update/Deprovision", func() {
+	Describe("Postgres Instance Provision/Bind/Deprovision", func() {
 		var (
 			instanceID string
 			serviceID  string
@@ -134,7 +134,7 @@ var _ = Describe("RDS Broker Daemon", func() {
 		})
 	})
 
-	Describe("MySQL Instance Provision/Update/Deprovision", func() {
+	Describe("MySQL Instance Provision/Bind/Deprovision", func() {
 		var (
 			instanceID string
 			serviceID  string


### PR DESCRIPTION
## What

Improve the integration tests for MySQL by testing connection and rebind permissions. Also refactor the tests so that there's no duplication between Postgres and MySQL.

I'm raising this ahead of the TLS work I'm doing because it depends on it but it may be easier to review independently.

## How to review

- It's probably easier to review the commits one-by-one, reading the commit message, and viewing the diff without whitespace changes
- Confirm that the integration tests pass (status will be submitted to this PR)
- Confirm that the test coverage hasn't been reduced
- General code review

## Who can review

Anyone