### PR TITLE
[#147829023] Utility to get master password for an instance

### DIFF
--- a/rds-broker-passwd/main.go
+++ b/rds-broker-passwd/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/alphagov/paas-rds-broker/rdsbroker"
+	"github.com/alphagov/paas-rds-broker/utils"
+)
+
+func main() {
+	var seed, instance string
+
+	fmt.Printf("master password seed: ")
+	fmt.Scanln(&seed)
+	fmt.Printf("instance uuid: ")
+	fmt.Scanln(&instance)
+
+	fmt.Printf("\n%s\n", utils.GetMD5B64(seed+instance, rdsbroker.MasterPasswordLength))
+}

--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -17,8 +17,8 @@ import (
 	"github.com/alphagov/paas-rds-broker/utils"
 )
 
-const masterUsernameLength = 16
-const masterPasswordLength = 32
+const MasterUsernameLength = 16
+const MasterPasswordLength = 32
 
 const instanceIDLogKey = "instance-id"
 const bindingIDLogKey = "binding-id"
@@ -610,11 +610,11 @@ func (b *RDSBroker) dbInstanceIdentifierToServiceInstanceID(serviceInstanceID st
 }
 
 func (b *RDSBroker) generateMasterUsername() string {
-	return utils.RandomAlphaNum(masterUsernameLength)
+	return utils.RandomAlphaNum(MasterUsernameLength)
 }
 
 func (b *RDSBroker) generateMasterPassword(instanceID string) string {
-	return utils.GetMD5B64(b.masterPasswordSeed+instanceID, masterPasswordLength)
+	return utils.GetMD5B64(b.masterPasswordSeed+instanceID, MasterPasswordLength)
 }
 
 func (b *RDSBroker) dbName(instanceID string) string {


### PR DESCRIPTION
## What

This can be useful when debugging a service instance.

It can be used with the username from:

    aws rds describe-db-instances \
      --db-instance-identifier <DB_PREFIX>-<SERVICE_INSTANCE_ID> \
      --query 'DBInstances[].MasterUsername'

I've made the username and password length constants public so that they can
be re-used by this separate package and not get out-of-sync.

I've made it interactive, rather than taking CLI arguments, to prevent
someone from storing the master seed password in their shell history.

## How to review

1. Code review
1. Optional: use it to connect to a service instance in your dev environment. You'll need:
    - a Postgres or MySQL service instance
    - username as described above
    - master seed password from `cf-secrets.yml`
    - an SSH tunnel via an app

## Who can review

Anyone