### PR TITLE
[#149398715] Add ssl option to JDBC

### DIFF
--- a/sqlengine/postgres_engine.go
+++ b/sqlengine/postgres_engine.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"database/sql"
 	"fmt"
+	"net/url"
 	"text/template"
 
 	"github.com/lib/pq" // PostgreSQL Driver
@@ -245,7 +246,14 @@ func (d *PostgresEngine) URI(address string, port int64, dbname string, username
 }
 
 func (d *PostgresEngine) JDBCURI(address string, port int64, dbname string, username string, password string) string {
-	return fmt.Sprintf("jdbc:postgresql://%s:%d/%s?user=%s&password=%s", address, port, dbname, username, password)
+	params := &url.Values{}
+	params.Set("user", username)
+	params.Set("password", password)
+
+	if d.requireSSL {
+		params.Set("ssl", "true")
+	}
+	return fmt.Sprintf("jdbc:postgresql://%s:%d/%s?%s", address, port, dbname, params.Encode())
 }
 
 // generatePostgresGroup produces a deterministic group name. This is because the role

--- a/sqlengine/postgres_engine_test.go
+++ b/sqlengine/postgres_engine_test.go
@@ -178,6 +178,21 @@ var _ = Describe("PostgresEngine", func() {
 		dropTestUser(template1ConnectionString, masterUsername)
 	})
 
+	Context("can construct JDBC URI", func() {
+
+		It("when SSL is enabled", func() {
+			postgresEngine.requireSSL = true
+			jdbcuri := postgresEngine.JDBCURI(address, port, dbname, masterUsername, masterPassword)
+			Expect(jdbcuri).To(ContainSubstring("ssl=true"))
+		})
+
+		It("when SSL is disabled", func() {
+			postgresEngine.requireSSL = false
+			jdbcuri := postgresEngine.JDBCURI(address, port, dbname, masterUsername, masterPassword)
+			Expect(jdbcuri).ToNot(ContainSubstring("ssl=true"))
+		})
+	})
+
 	It("can connect to the new DB", func() {
 		err := postgresEngine.Open(address, port, dbname, masterUsername, masterPassword)
 		defer postgresEngine.Close()


### PR DESCRIPTION
## What

This came as a DeskPro request and was converted to a story.

It is required to add ssl option to JDBC URI if we want users to use ssl
connections. Unfortunately we disable SSL for travis test for now so we
can only check if ssl=false. This however seems good enough in the time
being.

## How to review
- sanity check
- run tests

## Who

Not @combor