### PR TITLE
[#149421867] Concurrency improvements to avoid reassign_owned bug

### DIFF
--- a/sqlengine/postgres_engine.go
+++ b/sqlengine/postgres_engine.go
@@ -4,12 +4,21 @@ import (
 	"bytes"
 	"database/sql"
 	"fmt"
+	"math/rand"
 	"net/url"
 	"text/template"
+	"time"
 
 	"github.com/lib/pq" // PostgreSQL Driver
 
 	"code.cloudfoundry.org/lager"
+)
+
+const (
+	pqErrUniqueViolation  = "23505"
+	pqErrDuplicateContent = "42710"
+	pqErrInternalError    = "XX000"
+	pqErrInvalidPassword  = "28P01"
 )
 
 type PostgresEngine struct {
@@ -43,7 +52,7 @@ func (d *PostgresEngine) Open(address string, port int64, dbname string, usernam
 		// We specifically look for invalid password error and map it to a
 		// generic error that can be the same across other engines
 		// See: https://www.postgresql.org/docs/9.3/static/errcodes-appendix.html
-		if pqErr, ok := err.(*pq.Error); ok && pqErr.Code == "28P01" {
+		if pqErr, ok := err.(*pq.Error); ok && pqErr.Code == pqErrInvalidPassword {
 			// return &LoginFailedError{username}
 			return LoginFailedError
 		}
@@ -59,33 +68,33 @@ func (d *PostgresEngine) Close() {
 	}
 }
 
-func (d *PostgresEngine) CreateUser(bindingID, dbname string) (username, password string, err error) {
+func (d *PostgresEngine) execCreateUser(tx *sql.Tx, bindingID, dbname string) (username, password string, err error) {
 	groupname := d.generatePostgresGroup(dbname)
 
-	if err = d.ensureGroup(dbname, groupname); err != nil {
+	if err = d.ensureGroup(tx, dbname, groupname); err != nil {
 		return "", "", err
 	}
 
-	if err = d.ensureTrigger(groupname); err != nil {
+	if err = d.ensureTrigger(tx, groupname); err != nil {
 		return "", "", err
 	}
 
 	username = generateUsername(bindingID)
 	password = generatePassword()
 
-	if err = d.ensureUser(dbname, username, password); err != nil {
+	if err = d.ensureUser(tx, dbname, username, password); err != nil {
 		return "", "", err
 	}
 
 	grantPrivilegesStatement := fmt.Sprintf(`grant "%s" to "%s"`, groupname, username)
 	d.logger.Debug("grant-privileges", lager.Data{"statement": grantPrivilegesStatement})
 
-	if _, err := d.db.Exec(grantPrivilegesStatement); err != nil {
+	if _, err := tx.Exec(grantPrivilegesStatement); err != nil {
 		d.logger.Error("Grant sql-error", err)
 		return "", "", err
 	}
 
-	err = d.MigrateLegacyAdminUsers(bindingID, dbname)
+	err = d.MigrateLegacyAdminUsers(tx, bindingID, dbname)
 	if err != nil {
 		d.logger.Error("Migrate sql-error", err)
 	}
@@ -93,7 +102,42 @@ func (d *PostgresEngine) CreateUser(bindingID, dbname string) (username, passwor
 	return username, password, nil
 }
 
-func (d *PostgresEngine) MigrateLegacyAdminUsers(bindingID, dbname string) (err error) {
+func (d *PostgresEngine) createUser(bindingID, dbname string) (username, password string, err error) {
+	tx, err := d.db.Begin()
+	if err != nil {
+		d.logger.Error("sql-error", err)
+		return "", "", err
+	}
+	username, password, err = d.execCreateUser(tx, bindingID, dbname)
+	if err != nil {
+		_ = tx.Rollback()
+		return "", "", err
+	}
+	return username, password, tx.Commit()
+}
+
+func (d *PostgresEngine) CreateUser(bindingID, dbname string) (username, password string, err error) {
+	var pqErr *pq.Error
+	tries := 0
+	for tries < 10 {
+		tries++
+		username, password, err := d.createUser(bindingID, dbname)
+		if err != nil {
+			var ok bool
+			pqErr, ok = err.(*pq.Error)
+			if ok && (pqErr.Code == pqErrInternalError || pqErr.Code == pqErrDuplicateContent || pqErr.Code == pqErrUniqueViolation) {
+				time.Sleep(time.Duration(rand.Intn(1500)) * time.Millisecond)
+				continue
+			}
+			return "", "", err
+		}
+		return username, password, nil
+	}
+	return "", "", pqErr
+
+}
+
+func (d *PostgresEngine) MigrateLegacyAdminUsers(tx *sql.Tx, bindingID, dbname string) (err error) {
 	groupname := d.generatePostgresGroup(dbname)
 
 	usersMigrate, err := d.listLegacyAdminUsers()
@@ -105,7 +149,7 @@ func (d *PostgresEngine) MigrateLegacyAdminUsers(bindingID, dbname string) (err 
 		addAdminPrivilegesStatement := fmt.Sprintf(`grant "%s" to current_user with admin option`, username)
 		d.logger.Debug("grant-privileges", lager.Data{"statement": addAdminPrivilegesStatement})
 
-		if _, err := d.db.Exec(addAdminPrivilegesStatement); err != nil {
+		if _, err := tx.Exec(addAdminPrivilegesStatement); err != nil {
 			d.logger.Error("sql-error", err)
 			return err
 		}
@@ -113,7 +157,7 @@ func (d *PostgresEngine) MigrateLegacyAdminUsers(bindingID, dbname string) (err 
 		grantPrivilegesStatement := fmt.Sprintf(`grant "%s" to "%s"`, groupname, username)
 		d.logger.Debug("grant-privileges", lager.Data{"statement": grantPrivilegesStatement})
 
-		if _, err := d.db.Exec(grantPrivilegesStatement); err != nil {
+		if _, err := tx.Exec(grantPrivilegesStatement); err != nil {
 			d.logger.Error("sql-error", err)
 			return err
 		}
@@ -121,7 +165,7 @@ func (d *PostgresEngine) MigrateLegacyAdminUsers(bindingID, dbname string) (err 
 		reassignStatement := fmt.Sprintf(`reassign owned by "%s" to "%s"`, username, groupname)
 		d.logger.Debug("reassign-objects", lager.Data{"statement": reassignStatement})
 
-		if _, err := d.db.Exec(reassignStatement); err != nil {
+		if _, err := tx.Exec(reassignStatement); err != nil {
 			d.logger.Error("sql-error", err)
 			return err
 		}
@@ -129,7 +173,7 @@ func (d *PostgresEngine) MigrateLegacyAdminUsers(bindingID, dbname string) (err 
 		removeAdminPrivilegesStatement := fmt.Sprintf(`revoke "%s" from current_user`, username)
 		d.logger.Debug("grant-privileges", lager.Data{"statement": removeAdminPrivilegesStatement})
 
-		if _, err := d.db.Exec(removeAdminPrivilegesStatement); err != nil {
+		if _, err := tx.Exec(removeAdminPrivilegesStatement); err != nil {
 			d.logger.Error("sql-error", err)
 			return err
 		}
@@ -275,7 +319,7 @@ const ensureGroupPattern = `
 
 var ensureGroupTemplate = template.Must(template.New("ensureGroup").Parse(ensureGroupPattern))
 
-func (d *PostgresEngine) ensureGroup(dbname, groupname string) error {
+func (d *PostgresEngine) ensureGroup(tx *sql.Tx, dbname, groupname string) error {
 	var ensureGroupStatement bytes.Buffer
 	if err := ensureGroupTemplate.Execute(&ensureGroupStatement, map[string]string{
 		"role": groupname,
@@ -284,7 +328,7 @@ func (d *PostgresEngine) ensureGroup(dbname, groupname string) error {
 	}
 	d.logger.Debug("ensure-group", lager.Data{"statement": ensureGroupStatement.String()})
 
-	if _, err := d.db.Exec(ensureGroupStatement.String()); err != nil {
+	if _, err := tx.Exec(ensureGroupStatement.String()); err != nil {
 		d.logger.Error("sql-error", err)
 		return err
 	}
@@ -295,30 +339,30 @@ func (d *PostgresEngine) ensureGroup(dbname, groupname string) error {
 const ensureTriggerPattern = `
 	create or replace function reassign_owned() returns event_trigger language plpgsql as $$
 	begin
-		IF pg_has_role(current_user, '{{.role}}', 'member') AND
-		   NOT EXISTS (SELECT 1 FROM pg_user WHERE usename = current_user and usesuper = true)
-		THEN
-			EXECUTE 'reassign owned by "' || current_user || '" to "{{.role}}"';
-		end if;
+		-- do not execute if member of rds_superuser
+		IF EXISTS (select 1 from pg_catalog.pg_roles where rolname = 'rds_superuser')
+		AND pg_has_role(current_user, 'rds_superuser', 'member') THEN
+			RETURN;
+		END IF;
+
+		-- do not execute if not member of manager role	
+		IF NOT pg_has_role(current_user, '{{.role}}', 'member') THEN
+			RETURN;
+		END IF;
+		
+		-- do not execute if superuser
+		IF EXISTS (SELECT 1 FROM pg_user WHERE usename = current_user and usesuper = true) THEN
+			RETURN;
+		END IF;
+
+		EXECUTE 'reassign owned by "' || current_user || '" to "{{.role}}"';
 	end
 	$$;
 	`
 
 var ensureTriggerTemplate = template.Must(template.New("ensureTrigger").Parse(ensureTriggerPattern))
 
-func (d *PostgresEngine) ensureTrigger(groupname string) error {
-	tx, err := d.db.Begin()
-	if err != nil {
-		return err
-	}
-
-	commitCalled := false
-	defer func() {
-		if !commitCalled {
-			tx.Rollback()
-		}
-	}()
-
+func (d *PostgresEngine) ensureTrigger(tx *sql.Tx, groupname string) error {
 	var ensureTriggerStatement bytes.Buffer
 	if err := ensureTriggerTemplate.Execute(&ensureTriggerStatement, map[string]string{
 		"role": groupname,
@@ -334,18 +378,11 @@ func (d *PostgresEngine) ensureTrigger(groupname string) error {
 
 	for _, cmd := range cmds {
 		d.logger.Debug("ensure-trigger", lager.Data{"statement": cmd})
-		_, err = tx.Exec(cmd)
+		_, err := tx.Exec(cmd)
 		if err != nil {
 			d.logger.Error("sql-error", err)
 			return err
 		}
-	}
-
-	err = tx.Commit()
-	commitCalled = true
-	if err != nil {
-		d.logger.Error("commit.sql-error", err)
-		return err
 	}
 
 	return nil
@@ -367,7 +404,7 @@ const ensureCreateUserPattern = `
 
 var ensureCreateUserTemplate = template.Must(template.New("ensureUser").Parse(ensureCreateUserPattern))
 
-func (d *PostgresEngine) ensureUser(dbname string, username string, password string) error {
+func (d *PostgresEngine) ensureUser(tx *sql.Tx, dbname string, username string, password string) error {
 	var ensureUserStatement bytes.Buffer
 	if err := ensureCreateUserTemplate.Execute(&ensureUserStatement, map[string]string{
 		"password": password,
@@ -384,7 +421,7 @@ func (d *PostgresEngine) ensureUser(dbname string, username string, password str
 	}
 	d.logger.Debug("ensure-user", lager.Data{"statement": ensureUserStatementSanitized.String()})
 
-	if _, err := d.db.Exec(ensureUserStatement.String()); err != nil {
+	if _, err := tx.Exec(ensureUserStatement.String()); err != nil {
 		d.logger.Error("sql-error", err)
 		return err
 	}


### PR DESCRIPTION
# What

### The "reassigned_owner bug"!

* `grant "xxxx_owner" to current_user with admin option` is executed as part of a block of statements intended to handle the legacy user migration within the `CreateUser` function which is called on each Bind.
    * (due to some other grant statements) this grant also causes the current_user to assume membership of the rdsbroker_xxx_manager role 
    * While executing SQL from the broker `current_user` is the RDS assigned user role.
    * This RDS assigned user is NOT a superuser (it is a member of the `rds_superuser` role)
    * The grant is reversed/revoked at the end of the block of migration related statements once it is no longer needed 
    * This block of statements is NOT within a transaction.
* When executed multiple times in parallel it is possible for statements to be executed after the grant but before the revoke
    * ...this causes the guard in the reassign_owner trigger [`pg_has_role(current_user, 'rdsbroker_xxx_manager', 'member')`] to pass as true (when it would usually be false)
    * ...which causes the reassignment of all `current_user` objects (including the trigger function itself) to the `rdsbroker_xxx_manager` role
    * ...which causes all future executions of the `create or replace` or `drop` statements to fail since the owner is now incorrect!

For an annotated log of the issue from a dev postgres instance can be found [here](https://hackmd.io/JwDgjApsBswCYFoDGAGA7AJgQFjnNCARrgGYIgCsEc2ISFc0lQA=?view)

### Related issues...

* While testing under high concurrency (~10 connections), several other issues cropped up:
    * Continuous attempts to create the manager role in parallel caused unique key errors
    * Attempts to replace the trigger func caused lock errors
 
### Fixes in this PR

* [x] Place all of `CreateUser` within a transaction to avoid other connections seeing the state of the grant when they shouldn't.
* [x] Add another guard to the trigger function to prevent the rds_superuser executing it even if the role matches
* [x] Add retry loops to failing transaction due to locks/concurrent updates to better handle concurrent connections
* [x] Randomize sleep between retries toreduce likelyhood of continued failures of retries

# How to Review

* Code review
* Ensure that fast concurrent bind/unbind calls does not lead to the owner of the `reassigned_owned` function becoming the `rdsbroke_*_manager` user.
   - Here's a [rough script](https://gist.github.com/chrisfarms/6910ef66d354ad12963fa98a2eabdb17) to help with hammering your dev environment with concurrent bind/unbinds (requires `npm install -g concurretly`)
  - If ran against current master it should show errors about incorrect owner / permissions after about 15 seconds or so of abuse and the reassign_owner function should incorrectly end up owned by the rdsbroker_*_manager user
  - if ran against this branch you should not see any errors and the function should never change ownership no matter how long you hammer it
  - You can login to the rds instance psql console [like this](https://hackmd.io/BwJgLKCmwGYLSQGwCMDGcyuGOBDMYAzHDGCMocjLpIZAAxA=?view)

# Who can review

Not @chrisfarms or @paroxp 