### PR TITLE
[#149722039] Fix snapshot restore with legacy users

### DIFF
--- a/sqlengine/mysql_engine_test.go
+++ b/sqlengine/mysql_engine_test.go
@@ -8,8 +8,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"fmt"
-
 	"code.cloudfoundry.org/lager"
 )
 
@@ -68,8 +66,6 @@ var _ = Describe("MySQLEngine", func() {
 		dbname = "mydb" + randomTestSuffix
 
 		template1ConnectionString = mysqlEngine.connectionString(address, port, "", username, password)
-
-		fmt.Println(template1ConnectionString)
 
 		// Create the test DB
 		createMysqlDB(template1ConnectionString, dbname)

--- a/sqlengine/postgres_engine.go
+++ b/sqlengine/postgres_engine.go
@@ -126,6 +126,14 @@ func (d *PostgresEngine) MigrateLegacyAdminUsers(bindingID, dbname string) (err 
 			return err
 		}
 
+		revokeStatement := fmt.Sprintf(`revoke all privileges on database "%s" from "%s"`, dbname, username)
+		d.logger.Debug("revoke-permissions", lager.Data{"statement": revokeStatement})
+
+		if _, err := d.db.Exec(revokeStatement); err != nil {
+			d.logger.Error("sql-error", err)
+			return err
+		}
+
 		removeAdminPrivilegesStatement := fmt.Sprintf(`revoke "%s" from current_user`, username)
 		d.logger.Debug("grant-privileges", lager.Data{"statement": removeAdminPrivilegesStatement})
 

--- a/sqlengine/postgres_engine_test.go
+++ b/sqlengine/postgres_engine_test.go
@@ -286,9 +286,7 @@ var _ = Describe("PostgresEngine", func() {
 				legacyUserName, legacyUserPassword = createLegacyUser(masterConnectionString, dbname)
 				connectionStringLegacy = postgresEngine.URI(address, port, dbname, legacyUserName, legacyUserPassword)
 				createObjects(connectionStringLegacy, "legacy_table")
-			})
 
-			BeforeEach(func() {
 				bindingID = "binding-id" + randomTestSuffix
 				err := postgresEngine.Open(address, port, dbname, masterUsername, masterPassword)
 				Expect(err).ToNot(HaveOccurred())
@@ -314,6 +312,11 @@ var _ = Describe("PostgresEngine", func() {
 				accessAndDeleteObjects(connectionStringLegacy, "new_table")
 			})
 
+			It("Leaves the legacy user with no ownerships and direct permissions so that ResetState() can drop it", func() {
+				// Otherwise restoring snapshots of databases with legacy users will fail
+				err := postgresEngine.ResetState()
+				Expect(err).ToNot(HaveOccurred())
+			})
 		})
 	})
 


### PR DESCRIPTION
## What

As part of the post-restore process for a database instance created from
a snapshot, the broker drops all existing users (not groups) that exist.
This is because their corresponding bindings won't exist in CF.

Postgres doesn't allow dropping a user that owns any objects, or has any
permissions assigned (other than membership of other roles). The legacy
user had been granted permissions on the database, which resulted in the
post-migration tasks failing with the error:

```
ERROR:  role "rdsbroker_<UUID>_owner" cannot be dropped because some objects depend on it
DETAIL:  privileges for database rdsbroker_<UUID>
```

Updating MigrateLegacyAdminUsers to revoke these permissions from the
legacy user allows the user to be dropped. The legacy user no longer
needs these permissions because it's now been made a member of the
_manager group, and gets its permissions via that.

## How to review

Code review is probably enough.

## Who can review

Not me.