### PR TITLE
[#149144401] Allow `CREATE SCHEMA`

### DIFF
--- a/ci/blackbox/rdsbroker_test.go
+++ b/ci/blackbox/rdsbroker_test.go
@@ -100,7 +100,7 @@ var _ = Describe("RDS Broker Daemon", func() {
 				By("using those credentials to create objects")
 				credentials, err := getCredentialsFromBindResponse(resp)
 				Expect(err).ToNot(HaveOccurred())
-				err = setupPermissionsTest(credentials.URI, serviceID)
+				err = setupPermissionsTest(credentials.URI)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("re-binding")
@@ -114,7 +114,7 @@ var _ = Describe("RDS Broker Daemon", func() {
 				By("using the new credentials to alter existing objects")
 				credentials, err = getCredentialsFromBindResponse(resp)
 				Expect(err).ToNot(HaveOccurred())
-				err = permissionsTest(credentials.URI, serviceID)
+				err = permissionsTest(credentials.URI)
 				Expect(err).ToNot(HaveOccurred())
 			})
 		}
@@ -305,7 +305,7 @@ func openConnection(databaseURI string) (*sql.DB, error) {
 	return sql.Open(dbURL.Scheme, dsn)
 }
 
-func setupPermissionsTest(databaseURI, serviceID string) error {
+func setupPermissionsTest(databaseURI string) error {
 	db, err := openConnection(databaseURI)
 	if err != nil {
 		return err
@@ -322,7 +322,11 @@ func setupPermissionsTest(databaseURI, serviceID string) error {
 		return fmt.Errorf("Error inserting record: %s", err.Error())
 	}
 
-	switch serviceID {
+	dbURL, err := url.Parse(databaseURI)
+	if err != nil {
+		return err
+	}
+	switch dbURL.Scheme {
 	case "postgres":
 
 		_, err = db.Exec("CREATE SCHEMA foo")
@@ -345,7 +349,7 @@ func setupPermissionsTest(databaseURI, serviceID string) error {
 	return nil
 }
 
-func permissionsTest(databaseURI, serviceID string) error {
+func permissionsTest(databaseURI string) error {
 	db, err := openConnection(databaseURI)
 	if err != nil {
 		return err
@@ -367,7 +371,11 @@ func permissionsTest(databaseURI, serviceID string) error {
 		return fmt.Errorf("Error DROPing table: %s", err.Error())
 	}
 
-	switch serviceID {
+	dbURL, err := url.Parse(databaseURI)
+	if err != nil {
+		return err
+	}
+	switch dbURL.Scheme {
 	case "postgres":
 
 		_, err = db.Exec("DROP SCHEMA foo CASCADE")

--- a/ci/blackbox/rdsbroker_test.go
+++ b/ci/blackbox/rdsbroker_test.go
@@ -21,8 +21,7 @@ import (
 )
 
 const (
-	INSTANCE_CREATE_TIMEOUT  = 30 * time.Minute
-	permissionCheckTableName = "permissions_check"
+	INSTANCE_CREATE_TIMEOUT = 30 * time.Minute
 )
 
 var _ = Describe("RDS Broker Daemon", func() {
@@ -101,7 +100,7 @@ var _ = Describe("RDS Broker Daemon", func() {
 				By("using those credentials to create objects")
 				credentials, err := getCredentialsFromBindResponse(resp)
 				Expect(err).ToNot(HaveOccurred())
-				err = setupPermissionsTest(credentials.URI)
+				err = setupPermissionsTest(credentials.URI, serviceID)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("re-binding")
@@ -115,7 +114,7 @@ var _ = Describe("RDS Broker Daemon", func() {
 				By("using the new credentials to alter existing objects")
 				credentials, err = getCredentialsFromBindResponse(resp)
 				Expect(err).ToNot(HaveOccurred())
-				err = permissionsTest(credentials.URI)
+				err = permissionsTest(credentials.URI, serviceID)
 				Expect(err).ToNot(HaveOccurred())
 			})
 		}
@@ -306,49 +305,76 @@ func openConnection(databaseURI string) (*sql.DB, error) {
 	return sql.Open(dbURL.Scheme, dsn)
 }
 
-func setupPermissionsTest(databaseURI string) error {
+func setupPermissionsTest(databaseURI, serviceID string) error {
 	db, err := openConnection(databaseURI)
 	if err != nil {
 		return err
 	}
 	defer db.Close()
 
-	_, err = db.Exec("CREATE TABLE " + permissionCheckTableName + " (id integer)")
+	_, err = db.Exec("CREATE TABLE permissions_check (id integer)")
 	if err != nil {
 		return fmt.Errorf("Error creating table: %s", err.Error())
 	}
 
-	_, err = db.Exec("INSERT INTO " + permissionCheckTableName + " VALUES(42)")
+	_, err = db.Exec("INSERT INTO permissions_check VALUES(42)")
 	if err != nil {
 		return fmt.Errorf("Error inserting record: %s", err.Error())
+	}
+
+	switch serviceID {
+	case "postgres":
+
+		_, err = db.Exec("CREATE SCHEMA foo")
+		if err != nil {
+			return fmt.Errorf("Error creating a schema: %s", err.Error())
+		}
+
+		_, err = db.Exec("CREATE TABLE foo.bar (id integer)")
+		if err != nil {
+			return fmt.Errorf("Error creating a table within a schema: %s", err.Error())
+		}
+
+		_, err = db.Exec("INSERT INTO foo.bar (id) VALUES (1)")
+		if err != nil {
+			return fmt.Errorf("Error inserting into table within a schema: %s", err.Error())
+		}
+
 	}
 
 	return nil
 }
 
-func permissionsTest(databaseURI string) error {
+func permissionsTest(databaseURI, serviceID string) error {
 	db, err := openConnection(databaseURI)
 	if err != nil {
 		return err
 	}
 	defer db.Close()
 
-	// Can we write?
-	_, err = db.Exec("INSERT INTO " + permissionCheckTableName + " VALUES(43)")
+	_, err = db.Exec("INSERT INTO permissions_check VALUES (43)")
 	if err != nil {
 		return fmt.Errorf("Error inserting record: %s", err.Error())
 	}
 
-	// Can we ALTER?
-	_, err = db.Exec("ALTER TABLE " + permissionCheckTableName + " ADD COLUMN something INTEGER")
+	_, err = db.Exec("ALTER TABLE permissions_check ADD COLUMN something INTEGER")
 	if err != nil {
 		return fmt.Errorf("Error ALTERing table: %s", err.Error())
 	}
 
-	// Can we DROP?
-	_, err = db.Exec("DROP TABLE " + permissionCheckTableName)
+	_, err = db.Exec("DROP TABLE permissions_check")
 	if err != nil {
 		return fmt.Errorf("Error DROPing table: %s", err.Error())
+	}
+
+	switch serviceID {
+	case "postgres":
+
+		_, err = db.Exec("DROP SCHEMA foo CASCADE")
+		if err != nil {
+			return fmt.Errorf("Error dropping schema: %s", err.Error())
+		}
+
 	}
 
 	return nil

--- a/ci/helpers/brokerapi_helper.go
+++ b/ci/helpers/brokerapi_helper.go
@@ -162,73 +162,73 @@ func (b *BrokerAPIClient) DoUpdateRequest(instanceID, serviceID, planID string, 
 func (b *BrokerAPIClient) ProvisionInstance(instanceID, serviceID, planID string, paramJSON string) (responseCode int, operation string, err error) {
 	resp, err := b.DoProvisionRequest(instanceID, serviceID, planID, paramJSON)
 	if err != nil {
+		return 0, "", err
+	}
+	if resp.StatusCode != 200 && resp.StatusCode != 201 && resp.StatusCode != 202 {
+		return resp.StatusCode, "", nil
+	}
+
+	provisioningResponse := ProvisioningResponse{}
+
+	body, err := BodyBytes(resp)
+	if err != nil {
 		return resp.StatusCode, "", err
 	}
-	if resp.StatusCode == 200 || resp.StatusCode == 201 || resp.StatusCode == 202 {
-		provisioningResponse := ProvisioningResponse{}
 
-		body, err := BodyBytes(resp)
-		if err != nil {
-			return resp.StatusCode, "", err
-		}
-
-		err = json.Unmarshal(body, &provisioningResponse)
-		if err != nil {
-			return resp.StatusCode, "", err
-		}
-
-		return resp.StatusCode, provisioningResponse.Operation, err
+	err = json.Unmarshal(body, &provisioningResponse)
+	if err != nil {
+		return resp.StatusCode, "", err
 	}
 
-	return resp.StatusCode, "", nil
+	return resp.StatusCode, provisioningResponse.Operation, nil
 }
 
 func (b *BrokerAPIClient) DeprovisionInstance(instanceID, serviceID, planID string) (responseCode int, operation string, err error) {
 	resp, err := b.DoDeprovisionRequest(instanceID, serviceID, planID)
 	if err != nil {
+		return 0, "", err
+	}
+	if resp.StatusCode != 200 && resp.StatusCode != 201 && resp.StatusCode != 202 {
+		return resp.StatusCode, "", nil
+	}
+
+	provisioningResponse := ProvisioningResponse{}
+
+	body, err := BodyBytes(resp)
+	if err != nil {
 		return resp.StatusCode, "", err
 	}
-	if resp.StatusCode == 200 || resp.StatusCode == 201 || resp.StatusCode == 202 {
-		provisioningResponse := ProvisioningResponse{}
 
-		body, err := BodyBytes(resp)
-		if err != nil {
-			return resp.StatusCode, "", err
-		}
-
-		err = json.Unmarshal(body, &provisioningResponse)
-		if err != nil {
-			return resp.StatusCode, "", err
-		}
-
-		return resp.StatusCode, provisioningResponse.Operation, err
+	err = json.Unmarshal(body, &provisioningResponse)
+	if err != nil {
+		return resp.StatusCode, "", err
 	}
 
-	return resp.StatusCode, "", nil
+	return resp.StatusCode, provisioningResponse.Operation, nil
 }
 
 func (b *BrokerAPIClient) UpdateInstance(instanceID, serviceID, planID string, newPlanID string, paramJSON string) (responseCode int, operation string, err error) {
 	resp, err := b.DoUpdateRequest(instanceID, serviceID, planID, newPlanID, paramJSON)
 	if err != nil {
+		return 0, "", err
+	}
+	if resp.StatusCode != 200 && resp.StatusCode != 201 && resp.StatusCode != 202 {
+		return resp.StatusCode, "", nil
+	}
+
+	provisioningResponse := ProvisioningResponse{}
+
+	body, err := BodyBytes(resp)
+	if err != nil {
 		return resp.StatusCode, "", err
 	}
-	if resp.StatusCode == 200 || resp.StatusCode == 201 || resp.StatusCode == 202 {
-		provisioningResponse := ProvisioningResponse{}
 
-		body, err := BodyBytes(resp)
-		if err != nil {
-			return resp.StatusCode, "", err
-		}
-
-		err = json.Unmarshal(body, &provisioningResponse)
-		if err != nil {
-			return resp.StatusCode, "", err
-		}
-
-		return resp.StatusCode, provisioningResponse.Operation, err
+	err = json.Unmarshal(body, &provisioningResponse)
+	if err != nil {
+		return resp.StatusCode, "", err
 	}
 
-	return resp.StatusCode, "", nil
+	return resp.StatusCode, provisioningResponse.Operation, nil
 }
 
 func (b *BrokerAPIClient) DoLastOperationRequest(instanceID, serviceID, planID, operation string) (*http.Response, error) {

--- a/sqlengine/postgres_engine.go
+++ b/sqlengine/postgres_engine.go
@@ -190,7 +190,7 @@ func (d *PostgresEngine) MigrateLegacyAdminUsers(tx *sql.Tx, bindingID, dbname s
 		revokeStatement := fmt.Sprintf(`revoke all privileges on database "%s" from "%s"`, dbname, username)
 		d.logger.Debug("revoke-permissions", lager.Data{"statement": revokeStatement})
 
-		if _, err := d.db.Exec(revokeStatement); err != nil {
+		if _, err := tx.Exec(revokeStatement); err != nil {
 			d.logger.Error("sql-error", err)
 			return err
 		}

--- a/sqlengine/postgres_engine.go
+++ b/sqlengine/postgres_engine.go
@@ -102,14 +102,6 @@ func (d *PostgresEngine) execCreateUser(tx *sql.Tx, bindingID, dbname string) (u
 		return "", "", err
 	}
 
-	ensurePublicSchemaOwnedByGroup := fmt.Sprintf(`alter schema public owner to "%s"`, groupname)
-	d.logger.Debug("alter-owner", lager.Data{"statement": ensurePublicSchemaOwnedByGroup})
-
-	if _, err := tx.Exec(ensurePublicSchemaOwnedByGroup); err != nil {
-		d.logger.Error("Alter sql-error", err)
-		return "", "", err
-	}
-
 	err = d.MigrateLegacyAdminUsers(tx, bindingID, dbname)
 	if err != nil {
 		d.logger.Error("Migrate sql-error", err)

--- a/sqlengine/postgres_engine_test.go
+++ b/sqlengine/postgres_engine_test.go
@@ -268,6 +268,38 @@ var _ = Describe("PostgresEngine", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
+		It("creates a user with the necessary permissions on the database", func() {
+			connectionString := postgresEngine.URI(address, port, dbname, createdUser, createdPassword)
+			db, err := sql.Open("postgres", connectionString)
+			Expect(err).ToNot(HaveOccurred())
+			defer db.Close()
+
+			_, err = db.Exec("CREATE TABLE foo (col CHAR(8))")
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = db.Exec("INSERT INTO foo (col) VALUES ('value')")
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = db.Exec("CREATE SCHEMA bar")
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = db.Exec("CREATE TABLE bar.baz (col CHAR(8))")
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = db.Exec("INSERT INTO bar.baz (col) VALUES ('other')")
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = db.Exec("DROP TABLE bar.baz")
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = db.Exec("DROP SCHEMA bar CASCADE")
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = db.Exec("DROP SCHEMA public CASCADE")
+			Expect(err).ToNot(HaveOccurred())
+
+		})
+
 		Context("When there are two different bindings", func() {
 			var (
 				otherBindingID       string

--- a/sqlengine/postgres_engine_test.go
+++ b/sqlengine/postgres_engine_test.go
@@ -295,9 +295,6 @@ var _ = Describe("PostgresEngine", func() {
 			_, err = db.Exec("DROP SCHEMA bar CASCADE")
 			Expect(err).ToNot(HaveOccurred())
 
-			_, err = db.Exec("DROP SCHEMA public CASCADE")
-			Expect(err).ToNot(HaveOccurred())
-
 		})
 
 		Context("When there are two different bindings", func() {


### PR DESCRIPTION
## What

https://www.pivotaltracker.com/story/show/149144401

We want to allow people to execute CREATE SCHEMA in their broker-managed postgresql instances.

* Additional GRANT to the _manager group to give ALL priviledges to the database.
* ~~Changes the owner of the default "public" schema to the rds_xxx_manager group to allow users to remove it if they so wish.~~ (_see second commit message_)
* Tests to ensure CREATE/DROP schema is possible with the generated credentials
* Tests to ensure tables can be created and used within other schemas.

## How to review

* Check the code
* Run the tests
* Deploy to dev and maybe test with binding an app. If you want to deploy the broker we have a [build of the bosh release](https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/rds-broker-release/jobs/build-dev-release/builds/61), and a [branch on paas-cf](https://github.com/alphagov/paas-cf/tree/create-schema-permissions) which pins said release.

## Who can review

not @chrisfarms or @henrytk 