### PR TITLE
rds-broker-passwd tool: Allow passing inputs as cli flags

### DIFF
--- a/rds-broker-passwd/main.go
+++ b/rds-broker-passwd/main.go
@@ -1,19 +1,33 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 
 	"github.com/alphagov/paas-rds-broker/rdsbroker"
 	"github.com/alphagov/paas-rds-broker/utils"
 )
 
+var (
+	seed = flag.String("seed", "", "master password seed")
+	uuid = flag.String("id", "", "rds instance uuid")
+)
+
+func init() {
+	flag.Parse()
+}
+
 func main() {
-	var seed, instance string
+	if seed == nil || *seed == "" {
+		fmt.Printf("master password seed: ")
+		fmt.Scanln(seed)
+		fmt.Printf("\n")
+	}
+	if uuid == nil || *uuid == "" {
+		fmt.Printf("instance uuid: ")
+		fmt.Scanln(uuid)
+		fmt.Printf("\n")
+	}
 
-	fmt.Printf("master password seed: ")
-	fmt.Scanln(&seed)
-	fmt.Printf("instance uuid: ")
-	fmt.Scanln(&instance)
-
-	fmt.Printf("\n%s\n", utils.GetMD5B64(seed+instance, rdsbroker.MasterPasswordLength))
+	fmt.Println(utils.GetMD5B64(*seed+*uuid, rdsbroker.MasterPasswordLength))
 }


### PR DESCRIPTION

### What

I wanted to pass in the "seed" and "id" arguments as cli flags rather than interactive input so I can use in a little script.

This makes it possible to do `rds-broker-passwd --seed x --id y` and also keeps the original interactive method for any flags you don't set.

### How to review

See if you like it

### Who

Anyone who likes cli flags