### PR TITLE
Resolve race condition in RDS broker startup

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -89,6 +90,10 @@ func main() {
 
 	server := buildHTTPHandler(serviceBroker, logger, config)
 
+	listener, err := net.Listen("tcp", ":"+port)
+	if err != nil {
+		log.Fatalf("Error listening to port %s: %s", port, err)
+	}
 	fmt.Println("RDS Service Broker started on port " + port + "...")
-	http.ListenAndServe(":"+port, server)
+	http.Serve(listener, server)
 }


### PR DESCRIPTION
## What

The existing broker prints that it is ready to accept connections *before* binding to the TCP port. Someone trying to connect to it when that message is printed will be in a race condition with the port binding. In addition the ready message will have been printed even if the bind fails.

@henrytk and I suspect this is responsible for [an intermittent failure in the `rds-broker` pipeline](https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/rds-broker/jobs/tag-releases/builds/4). The integrations tests run as soon as the broker prints that it is ready, and they failed saying `connection refused` when connecting to the broker. This race condition seems a plausible cause.

In this commit we now listen to the port before printing the 'ready' message. This should resolve the problem.

## How to review

* [ ] Review the code changes.
* [ ] Check the CI build goes successfully.

## Who can review

Not @46bit @henrytk.