### PR TITLE
[#150879493] apply_at_maintenance_window param

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Update calls support the following optional [arbitrary parameters](https://docs.
 
 | Option                       | Type    | Description
 |:-----------------------------|:------- |:-----------
-| apply_immediately            | Boolean | Specifies whether the modifications in this request and any pending modifications are asynchronously applied as soon as possible, regardless of the Preferred Maintenance Window setting for the DB instance (*)
+| apply_at_maintenance_window  | Boolean | Specifies whether the modifications in this request and any pending modifications are asynchronously applied as soon as possible (default) or if they should be queued until the Preferred Maintenance Window setting for the DB instance (*)
 | backup_retention_period      | Integer | The number of days that Amazon RDS should retain automatic backups of the DB instance (between `0` and `35`) (*)
 | preferred_backup_window      | String  | The daily time range during which automated backups are created if automated backups are enabled (*)
 | preferred_maintenance_window | String  | The weekly time range during which system maintenance can occur (*)

--- a/ci/blackbox/rdsbroker_test.go
+++ b/ci/blackbox/rdsbroker_test.go
@@ -173,7 +173,7 @@ var _ = Describe("RDS Broker Daemon", func() {
 			})
 
 			It("should not create a final snapshot when `skip_final_snapshot` is set at provision time", func() {
-				code, operation, err := brokerAPIClient.ProvisionInstance(instanceID, serviceID, planID, `{"skip_final_snapshot": "true"}`)
+				code, operation, err := brokerAPIClient.ProvisionInstance(instanceID, serviceID, planID, `{"skip_final_snapshot":true}`)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(code).To(Equal(202))
 				state := pollForOperationCompletion(instanceID, serviceID, planID, operation)
@@ -204,7 +204,7 @@ var _ = Describe("RDS Broker Daemon", func() {
 				state := pollForOperationCompletion(instanceID, serviceID, planID, operation)
 				Expect(state).To(Equal("succeeded"))
 
-				code, operation, err = brokerAPIClient.UpdateInstance(instanceID, serviceID, planID, planID, `{"skip_final_snapshot": "true"}`)
+				code, operation, err = brokerAPIClient.UpdateInstance(instanceID, serviceID, planID, planID, `{"skip_final_snapshot":true}`)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(code).To(Equal(202))
 				state = pollForOperationCompletion(instanceID, serviceID, planID, operation)

--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -244,8 +244,11 @@ func (b *RDSBroker) Update(
 		return brokerapi.UpdateServiceSpec{}, ErrEncryptionNotUpdateable
 	}
 
+	// The following `applyImmediately` variable is simply inverted custom
+	// parameter to make things simpler to our tenants.
+	applyImmediately := !updateParameters.ApplyAtMaintenanceWindow
 	modifyDBInstance := b.modifyDBInstance(instanceID, servicePlan, updateParameters, details)
-	if err := b.dbInstance.Modify(b.dbInstanceIdentifier(instanceID), *modifyDBInstance, updateParameters.ApplyImmediately); err != nil {
+	if err := b.dbInstance.Modify(b.dbInstanceIdentifier(instanceID), *modifyDBInstance, applyImmediately); err != nil {
 		if err == awsrds.ErrDBInstanceDoesNotExist {
 			return brokerapi.UpdateServiceSpec{}, brokerapi.ErrInstanceDoesNotExist
 		}

--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -702,9 +702,11 @@ func (b *RDSBroker) createDBInstance(instanceID string, servicePlan ServicePlan,
 		dbInstanceDetails.PreferredMaintenanceWindow = provisionParameters.PreferredMaintenanceWindow
 	}
 
-	skipFinalSnapshot := strconv.FormatBool(servicePlan.RDSProperties.SkipFinalSnapshot)
-	if provisionParameters.SkipFinalSnapshot != "" {
-		skipFinalSnapshot = provisionParameters.SkipFinalSnapshot
+	var skipFinalSnapshot string
+	if provisionParameters.SkipFinalSnapshot != nil {
+		skipFinalSnapshot = strconv.FormatBool(*provisionParameters.SkipFinalSnapshot)
+	} else {
+		skipFinalSnapshot = strconv.FormatBool(servicePlan.RDSProperties.SkipFinalSnapshot)
 	}
 
 	dbInstanceDetails.Tags = b.dbTags("Created", details.ServiceID, details.PlanID, details.OrganizationGUID, details.SpaceGUID, skipFinalSnapshot, "")
@@ -713,9 +715,11 @@ func (b *RDSBroker) createDBInstance(instanceID string, servicePlan ServicePlan,
 
 func (b *RDSBroker) restoreDBInstance(instanceID, snapshotIdentifier string, servicePlan ServicePlan, provisionParameters ProvisionParameters, details brokerapi.ProvisionDetails) *awsrds.DBInstanceDetails {
 	dbInstanceDetails := b.dbInstanceFromPlan(servicePlan)
-	skipFinalSnapshot := strconv.FormatBool(servicePlan.RDSProperties.SkipFinalSnapshot)
-	if provisionParameters.SkipFinalSnapshot != "" {
-		skipFinalSnapshot = provisionParameters.SkipFinalSnapshot
+	var skipFinalSnapshot string
+	if provisionParameters.SkipFinalSnapshot != nil {
+		skipFinalSnapshot = strconv.FormatBool(*provisionParameters.SkipFinalSnapshot)
+	} else {
+		skipFinalSnapshot = strconv.FormatBool(servicePlan.RDSProperties.SkipFinalSnapshot)
 	}
 
 	dbInstanceDetails.Tags = b.dbTags("Created", details.ServiceID, details.PlanID, details.OrganizationGUID, details.SpaceGUID, skipFinalSnapshot, snapshotIdentifier)
@@ -745,9 +749,11 @@ func (b *RDSBroker) modifyDBInstance(instanceID string, servicePlan ServicePlan,
 		dbInstanceDetails.PreferredMaintenanceWindow = updateParameters.PreferredMaintenanceWindow
 	}
 
-	skipFinalSnapshot := strconv.FormatBool(servicePlan.RDSProperties.SkipFinalSnapshot)
-	if updateParameters.SkipFinalSnapshot != "" {
-		skipFinalSnapshot = updateParameters.SkipFinalSnapshot
+	var skipFinalSnapshot string
+	if updateParameters.SkipFinalSnapshot != nil {
+		skipFinalSnapshot = strconv.FormatBool(*updateParameters.SkipFinalSnapshot)
+	} else {
+		skipFinalSnapshot = strconv.FormatBool(servicePlan.RDSProperties.SkipFinalSnapshot)
 	}
 
 	dbInstanceDetails.Tags = b.dbTags("Updated", details.ServiceID, details.PlanID, "", "", skipFinalSnapshot, "")

--- a/rdsbroker/broker_test.go
+++ b/rdsbroker/broker_test.go
@@ -944,15 +944,6 @@ var _ = Describe("RDS Broker", func() {
 				})
 			})
 			Context("when Parameters are not valid", func() {
-				BeforeEach(func() {
-					provisionDetails.RawParameters = json.RawMessage(`{"skip_final_snapshot": "invalid"}`)
-				})
-
-				It("returns the proper error", func() {
-					_, err := rdsBroker.Provision(ctx, instanceID, provisionDetails, acceptsIncomplete)
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("skip_final_snapshot must be set to true or false, or not set at all"))
-				})
 
 				Context("and user provision parameters are not allowed", func() {
 					BeforeEach(func() {
@@ -1439,16 +1430,6 @@ var _ = Describe("RDS Broker", func() {
 		})
 
 		Context("when Parameters are not valid", func() {
-			BeforeEach(func() {
-				updateDetails.RawParameters = json.RawMessage(`{"skip_final_snapshot": "invalid"}`)
-			})
-
-			It("returns the proper error", func() {
-				_, err := rdsBroker.Update(ctx, instanceID, updateDetails, acceptsIncomplete)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("skip_final_snapshot must be set to true or false, or not set at all"))
-			})
-
 			Context("and user update parameters are not allowed", func() {
 				BeforeEach(func() {
 					allowUserUpdateParameters = false

--- a/rdsbroker/parameters.go
+++ b/rdsbroker/parameters.go
@@ -5,20 +5,20 @@ import (
 )
 
 type ProvisionParameters struct {
-	BackupRetentionPeriod       int64
-	CharacterSetName            string
-	DBName                      string
-	PreferredBackupWindow       string
-	PreferredMaintenanceWindow  string
+	BackupRetentionPeriod       int64   `json:"backup_retention_period"`
+	CharacterSetName            string  `json:"character_set_name"`
+	DBName                      string  `json:"dbname"`
+	PreferredBackupWindow       string  `json:"preferred_backup_window"`
+	PreferredMaintenanceWindow  string  `json:"preferred_maintenance_window"`
 	SkipFinalSnapshot           string  `json:"skip_final_snapshot"`
 	RestoreFromLatestSnapshotOf *string `json:"restore_from_latest_snapshot_of"`
 }
 
 type UpdateParameters struct {
-	ApplyAtMaintenanceWindow   bool `json:"apply_at_maintenance_window,omitempty"`
-	BackupRetentionPeriod      int64
-	PreferredBackupWindow      string
-	PreferredMaintenanceWindow string
+	ApplyAtMaintenanceWindow   bool   `json:"apply_at_maintenance_window"`
+	BackupRetentionPeriod      int64  `json:"backup_retention_period"`
+	PreferredBackupWindow      string `json:"preferred_backup_window"`
+	PreferredMaintenanceWindow string `json:"preferred_maintenance_window"`
 	SkipFinalSnapshot          string `json:"skip_final_snapshot"`
 }
 

--- a/rdsbroker/parameters.go
+++ b/rdsbroker/parameters.go
@@ -15,7 +15,7 @@ type ProvisionParameters struct {
 }
 
 type UpdateParameters struct {
-	ApplyImmediately           bool
+	ApplyAtMaintenanceWindow   bool `json:"apply_at_maintenance_window,omitempty"`
 	BackupRetentionPeriod      int64
 	PreferredBackupWindow      string
 	PreferredMaintenanceWindow string

--- a/rdsbroker/parameters.go
+++ b/rdsbroker/parameters.go
@@ -1,16 +1,12 @@
 package rdsbroker
 
-import (
-	"errors"
-)
-
 type ProvisionParameters struct {
 	BackupRetentionPeriod       int64   `json:"backup_retention_period"`
 	CharacterSetName            string  `json:"character_set_name"`
 	DBName                      string  `json:"dbname"`
 	PreferredBackupWindow       string  `json:"preferred_backup_window"`
 	PreferredMaintenanceWindow  string  `json:"preferred_maintenance_window"`
-	SkipFinalSnapshot           string  `json:"skip_final_snapshot"`
+	SkipFinalSnapshot           *bool   `json:"skip_final_snapshot"`
 	RestoreFromLatestSnapshotOf *string `json:"restore_from_latest_snapshot_of"`
 }
 
@@ -19,7 +15,7 @@ type UpdateParameters struct {
 	BackupRetentionPeriod      int64  `json:"backup_retention_period"`
 	PreferredBackupWindow      string `json:"preferred_backup_window"`
 	PreferredMaintenanceWindow string `json:"preferred_maintenance_window"`
-	SkipFinalSnapshot          string `json:"skip_final_snapshot"`
+	SkipFinalSnapshot          *bool  `json:"skip_final_snapshot"`
 }
 
 type BindParameters struct {
@@ -27,18 +23,10 @@ type BindParameters struct {
 	// bind-time parameters in future.
 }
 
-func Validate_SkipFinalSnapshot(SkipFinalSnapshot string) error {
-	switch SkipFinalSnapshot {
-	case "true", "false", "":
-		return nil
-	}
-	return errors.New("skip_final_snapshot must be set to true or false, or not set at all")
-}
-
 func (pp *ProvisionParameters) Validate() error {
-	return Validate_SkipFinalSnapshot(pp.SkipFinalSnapshot)
+	return nil
 }
 
 func (pp *UpdateParameters) Validate() error {
-	return Validate_SkipFinalSnapshot(pp.SkipFinalSnapshot)
+	return nil
 }


### PR DESCRIPTION
# What

We want to change the default behaviour of `Update` calls so that changes are applied immediately rather than at the next maintenance window.

We still want to allow uses to opt-in to using a maintenance window if desired.

This change drops the semi-documented `apply_immediately` param in favour of the default being to start applying updates immediately and a `apply_at_maintenance_window` param. 

# How to review

Probably best to do from https://github.com/alphagov/paas-cf/pull/1049

# Who can review

not @chrisfarms nor @paroxp 