### PR TITLE
[#152067657] Fix postgres unbind for legacy bindings.

### DIFF
--- a/sqlengine/postgres_engine.go
+++ b/sqlengine/postgres_engine.go
@@ -145,6 +145,13 @@ func (d *PostgresEngine) DropUser(bindingID string) error {
 	dropUserStatement := fmt.Sprintf(`drop role "%s"`, username)
 
 	if _, err := d.db.Exec(dropUserStatement); err != nil {
+		// When handling unbinds for bindings created before the switch to
+		// event-triggers based permissions the `username` won't exist. We
+		// swallow the error to prevent unbinding from failing.
+		if pqErr, ok := err.(*pq.Error); ok && pqErr.Code == "42704" {
+			d.logger.Info("warning", lager.Data{"warning": "User " + username + " does not exist"})
+			return nil
+		}
 		d.logger.Error("sql-error", err)
 		return err
 	}

--- a/sqlengine/postgres_engine_test.go
+++ b/sqlengine/postgres_engine_test.go
@@ -353,17 +353,9 @@ var _ = Describe("PostgresEngine", func() {
 				Expect(pqErr.Message).To(MatchRegexp("role .* does not exist"))
 			})
 
-			It("Calling DropUser() twice fails with 'role does not exist'", func() {
-				err := postgresEngine.DropUser(bindingID)
-				Expect(err).ToNot(HaveOccurred())
-				err = postgresEngine.DropUser(bindingID)
-				pqErr, ok := err.(*pq.Error)
-				Expect(ok).To(BeTrue())
-				Expect(pqErr.Code).To(BeEquivalentTo("42704"))
-				Expect(pqErr.Message).To(MatchRegexp("role .* does not exist"))
-			})
+			It("Errors dropping the user are returned", func() {
+				// other than 'role does not exist' - see below
 
-			It("Other errors are not ignored", func() {
 				rootConnection, err := sql.Open("postgres", template1ConnectionString)
 				defer rootConnection.Close()
 				Expect(err).ToNot(HaveOccurred())
@@ -378,7 +370,13 @@ var _ = Describe("PostgresEngine", func() {
 				Expect(pqErr.Code).To(BeEquivalentTo("42501"))
 				Expect(pqErr.Message).To(MatchRegexp("permission denied to drop role"))
 			})
+		})
 
+		Context("A user doesn't exist", func() {
+			It("Calling DropUser() doesn't fail with 'role does not exist'", func() {
+				err := postgresEngine.DropUser(bindingID)
+				Expect(err).ToNot(HaveOccurred())
+			})
 		})
 
 	})


### PR DESCRIPTION
## What

We still have Postgres instances with bindings that were created before
we introduced the event triggers based permissions model. These bindings
are therefore using the shared rdsbroker_UUID_owner user.

Unbinding is currently failing for these users because it's trying to
drop the username derived from the binding ID, which doesn't exist. We
fix this by partially reverting 05942c88 so that DropUser doesn't error
if the role doesn't exist. (It's not safe to drop the rdsbroker_UUID_owner
user because it could be shared by multiple bindings)

## How to review

Test as part of https://github.com/alphagov/paas-cf/pull/1082

## Who can review

Not me.