### PR TITLE
Use SHA256 for generating hashes for usernames and database passwords

### DIFF
--- a/rds-broker-passwd/main.go
+++ b/rds-broker-passwd/main.go
@@ -15,5 +15,5 @@ func main() {
 	fmt.Printf("instance uuid: ")
 	fmt.Scanln(&instance)
 
-	fmt.Printf("\n%s\n", utils.GetMD5B64(seed+instance, rdsbroker.MasterPasswordLength))
+	fmt.Printf("\n%s\n", utils.GenerateHash(seed+instance, rdsbroker.MasterPasswordLength))
 }

--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -664,7 +664,7 @@ func (b *RDSBroker) generateMasterUsername() string {
 }
 
 func (b *RDSBroker) generateMasterPassword(instanceID string) string {
-	return utils.GetMD5B64(b.masterPasswordSeed+instanceID, MasterPasswordLength)
+	return utils.GenerateHash(b.masterPasswordSeed+instanceID, MasterPasswordLength)
 }
 
 func (b *RDSBroker) dbName(instanceID string) string {

--- a/rdsbroker/broker_test.go
+++ b/rdsbroker/broker_test.go
@@ -75,7 +75,7 @@ var _ = Describe("RDS Broker", func() {
 		dbInstanceIdentifier = "cf-instance-id"
 		dbName               = "cf_instance_id"
 		dbUsername           = "uvMSB820K_t3WvCX"
-		masterUserPassword   = "qOeiJ6AstR_mUQJxn6jyew=="
+		masterUserPassword   = "R2gfMWWb3naYDTL6rrBcGp-C5dmcThId"
 		instanceOrigID       = "instance-orig-id"
 	)
 

--- a/sqlengine/sql_engine.go
+++ b/sqlengine/sql_engine.go
@@ -26,7 +26,7 @@ type SQLEngine interface {
 var LoginFailedError = errors.New("Login failed")
 
 func generateUsername(seed string) string {
-	usernameString := strings.ToLower(utils.GetMD5B64(seed, usernameLength-1))
+	usernameString := strings.ToLower(utils.GenerateHash(seed, usernameLength-1))
 	return "u" + strings.Replace(usernameString, "-", "_", -1)
 }
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,8 +1,8 @@
 package utils
 
 import (
-	"crypto/md5"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
 	"io"
 )
@@ -42,9 +42,9 @@ func randChar(length int, chars []byte) string {
 	}
 }
 
-func GetMD5B64(text string, maxLength int) string {
-	md5 := md5.Sum([]byte(text))
-	encoded := base64.URLEncoding.EncodeToString(md5[:])
+func GenerateHash(text string, maxLength int) string {
+	hash := sha256.Sum256([]byte(text))
+	encoded := base64.URLEncoding.EncodeToString(hash[:])
 	if len(encoded) > maxLength {
 		return encoded[0:maxLength]
 	} else {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -14,23 +14,23 @@ var _ = Describe("RandomAlphaNum", func() {
 	})
 })
 
-var _ = Describe("GetMD5B64", func() {
-	It("returns the Base64 encoded MD5 hash of the given string", func() {
-		md5b64 := GetMD5B64("ce71b484-d542-40f7-9dd4-5526e38c81ba", 32)
+var _ = Describe("GenerateHash", func() {
+	It("returns the Base64 encoded SHA256 hash of the given string", func() {
+		hash := GenerateHash("ce71b484-d542-40f7-9dd4-5526e38c81ba", 64)
 		// Expectation generated with
-		// echo -n ce71b484-d542-40f7-9dd4-5526e38c81ba | openssl dgst -md5 -binary | openssl enc -base64
-		Expect(md5b64).To(Equal("OzUBBVyWFqGmb7pb54mPVQ=="))
+		// echo -n "ce71b484-d542-40f7-9dd4-5526e38c81ba" | openssl dgst -sha256 -binary | openssl enc -base64
+		Expect(hash).To(Equal("BJ3IzLRK6pmhB98A1S7RmgWkkgmK1MSQgKUMikmI7yQ="))
 	})
 
 	It("truncates the result when it's longer than the resuested max size", func() {
-		md5b64 := GetMD5B64("ce71b484-d542-40f7-9dd4-5526e38c81ba", 16)
-		Expect(md5b64).To(Equal("OzUBBVyWFqGmb7pb"))
+		hash := GenerateHash("ce71b484-d542-40f7-9dd4-5526e38c81ba", 32)
+		Expect(hash).To(Equal("BJ3IzLRK6pmhB98A1S7RmgWkkgmK1MSQ"))
 	})
 
 	It("Uses the URL safe base64 scheme", func() {
-		md5b64 := GetMD5B64("1123456678", 32)
+		hash := GenerateHash("1123456678", 64)
 		// Expectation generated with
-		// echo -n 1123456678 | openssl dgst -md5 -binary | openssl enc -base64 | tr '+/' '-_'
-		Expect(md5b64).To(Equal("4P7L73_9u3fGZbGG-GDHOw=="))
+		// echo -n 1123456678 | openssl dgst -sha256 -binary | openssl enc -base64 | tr '+/' '-_'
+		Expect(hash).To(Equal("180NZHG1Cx3N4mkrcboPAzOeJlXlYth4mKxjtzGhXMI="))
 	})
 })


### PR DESCRIPTION
## What

Use SHA256 for generating hashes for usernames and database passwords

During the pentest it came up that MD5 isn't considered safe anymore and we
should use SHA256 instead.

## How to review

Review as part of https://github.com/alphagov/paas-cf/pull/1353

## Who can review it

Not me.