### PR TITLE
[#156224236] Rotate master password in mysql RDS instances

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,11 @@ services:
 addons:
   postgresql: "9.5"
 
+env:
+  global:
+  - PGVERSION=9.5
+  - DB_PASSWORD=abc123
+
 before_install:
   - go get github.com/onsi/ginkgo/ginkgo
 
@@ -22,6 +27,13 @@ install:
 
 before_script:
   - psql -c 'create database mydb;' -U postgres
+  # Add authentication to postgresql
+  - psql -U postgres -c "ALTER USER postgres WITH PASSWORD '${DB_PASSWORD}';"
+  - sudo rm /etc/postgresql/$PGVERSION/main/pg_hba.conf
+  - echo "local all all trust" | sudo tee /etc/postgresql/$PGVERSION/main/pg_hba.conf
+  - echo "host all all 127.0.0.1 255.255.255.255 md5" | sudo tee -a /etc/postgresql/$PGVERSION/main/pg_hba.conf
+  - echo "host all all ::1/128 md5" | sudo tee -a /etc/postgresql/$PGVERSION/main/pg_hba.conf
+  - sudo service postgresql restart
 
 script:
-  - make unit
+  - make unit POSTGRESQL_PASSWORD=${DB_PASSWORD}

--- a/README.md
+++ b/README.md
@@ -116,19 +116,21 @@ There are two forms of tests for the broker, the unit tests and the integration 
 
 To run the tests of this broker, you need a Postgres and MySQL running locally, without SSL. The connection details can be configured using environment variables - see the `sqlengine` test suites for more information.
 
-In travis we use the [postgres service](https://docs.travis-ci.com/user/database-setup/#PostgreSQL) and the [mysql service](https://docs.travis-ci.com/user/database-setup/#MySQL)
+In travis we use the [postgres service](https://docs.travis-ci.com/user/database-setup/#PostgreSQL) and the [mysql service](https://docs.travis-ci.com/user/database-setup/#MySQL).
+
+We need to enable authentication on the postgres in order to test the wrong credential tests, as any password would be considered valid. In mysql is fine as only empty password is valid.
 
 Locally you can use containers with [Docker for Mac](https://docs.docker.com/docker-for-mac/) or [Docker for Linux](https://docs.docker.com/engine/installation/linux/ubuntu/):
 
 ```
-docker run -p 5432:5432 --name postgres -e POSTGRES_PASSWORD= -d postgres:9.5
+docker run -p 5432:5432 --name postgres -e POSTGRES_PASSWORD=abc123 -d postgres:9.5
 
 docker run -p 3306:3306 --name mysql -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -d mysql:5.7
 until docker exec mysql mysqladmin ping --silent; do
   printf "."; sleep 1
 done
 
-make unit
+make unit POSTGRESQL_PASSWORD=abc123
 
 docker rm -f postgres mysql
 ```

--- a/ci/blackbox/integration_suite_test.go
+++ b/ci/blackbox/integration_suite_test.go
@@ -1,22 +1,15 @@
 package integration_aws_test
 
 import (
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"os"
-	"os/exec"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/phayes/freeport"
 	uuid "github.com/satori/go.uuid"
 
 	"github.com/alphagov/paas-rds-broker/config"
@@ -25,16 +18,8 @@ import (
 )
 
 var (
-	rdsBrokerPath    string
-	rdsBrokerPort    int
-	rdsBrokerUrl     string
-	rdsBrokerSession *gexec.Session
-
-	brokerAPIClient *BrokerAPIClient
-
+	rdsBrokerPath   string
 	rdsBrokerConfig *config.Config
-
-	rdsClient *RDSClient
 
 	rdsSubnetGroupName *string
 	ec2SecurityGroupID *string
@@ -45,7 +30,7 @@ func TestSuite(t *testing.T) {
 		var err error
 
 		// Compile the broker
-		cp, err := gexec.Build("github.com/alphagov/paas-rds-broker")
+		rdsBrokerPath, err = gexec.Build("github.com/alphagov/paas-rds-broker")
 		Expect(err).ShouldNot(HaveOccurred())
 
 		// Update config
@@ -74,37 +59,6 @@ func TestSuite(t *testing.T) {
 				plan.RDSProperties.VpcSecurityGroupIds = []string{*ec2SecurityGroupID}
 			}
 		}
-
-		configFile, err := ioutil.TempFile("", "rds-broker")
-		Expect(err).ToNot(HaveOccurred())
-		defer os.Remove(configFile.Name())
-
-		configJSON, err := json.Marshal(rdsBrokerConfig)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(ioutil.WriteFile(configFile.Name(), configJSON, 0644)).To(Succeed())
-		Expect(configFile.Close()).To(Succeed())
-
-		// start the broker in a random port
-		rdsBrokerPort = freeport.GetPort()
-		command := exec.Command(cp,
-			fmt.Sprintf("-port=%d", rdsBrokerPort),
-			fmt.Sprintf("-config=%s", configFile.Name()),
-		)
-		rdsBrokerSession, err = gexec.Start(command, GinkgoWriter, GinkgoWriter)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Wait for it to be listening
-		Eventually(rdsBrokerSession, 10*time.Second).Should(And(
-			gbytes.Say("rds-broker.start"),
-			gbytes.Say(fmt.Sprintf(`{"port":"%d"}`, rdsBrokerPort)),
-		))
-
-		rdsBrokerUrl = fmt.Sprintf("http://localhost:%d", rdsBrokerPort)
-
-		brokerAPIClient = NewBrokerAPIClient(rdsBrokerUrl, rdsBrokerConfig.Username, rdsBrokerConfig.Password)
-		rdsClient, err = NewRDSClient(rdsBrokerConfig.RDSConfig.Region, rdsBrokerConfig.RDSConfig.DBPrefix)
-
-		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterSuite(func() {
@@ -117,7 +71,6 @@ func TestSuite(t *testing.T) {
 		if rdsSubnetGroupName != nil {
 			Expect(DestroySubnetGroup(rdsSubnetGroupName, awsSession)).To(Succeed())
 		}
-		rdsBrokerSession.Kill()
 	})
 
 	RegisterFailHandler(Fail)

--- a/sqlengine/mysql_engine_test.go
+++ b/sqlengine/mysql_engine_test.go
@@ -88,6 +88,13 @@ var _ = Describe("MySQLEngine", func() {
 		Expect(err).To(HaveOccurred())
 	})
 
+	It("returns error LoginFailedError if the credentials are wrong", func() {
+		err := mysqlEngine.Open(address, port, dbname, username, "wrong_password")
+		defer mysqlEngine.Close()
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(LoginFailedError))
+	})
+
 	Describe("User modification tests", func() {
 		var (
 			bindingID string

--- a/sqlengine/postgres_engine_test.go
+++ b/sqlengine/postgres_engine_test.go
@@ -356,8 +356,14 @@ var _ = Describe("PostgresEngine", func() {
 
 				pqErr, ok := err.(*pq.Error)
 				Expect(ok).To(BeTrue())
-				Expect(pqErr.Code).To(BeEquivalentTo("28000"))
-				Expect(pqErr.Message).To(MatchRegexp("role .* does not exist"))
+				Expect(pqErr.Code).To(SatisfyAny(
+					BeEquivalentTo("28P01"),
+					BeEquivalentTo("28000"),
+				))
+				Expect(pqErr.Message).To(SatisfyAny(
+					MatchRegexp("authentication failed for user"),
+					MatchRegexp("role .* does not exist"),
+				))
 			})
 
 			It("Errors dropping the user are returned", func() {
@@ -430,8 +436,14 @@ var _ = Describe("PostgresEngine", func() {
 
 				pqErr, ok := err.(*pq.Error)
 				Expect(ok).To(BeTrue())
-				Expect(pqErr.Code).To(BeEquivalentTo("28000"))
-				Expect(pqErr.Message).To(MatchRegexp("role .* does not exist"))
+				Expect(pqErr.Code).To(SatisfyAny(
+					BeEquivalentTo("28P01"),
+					BeEquivalentTo("28000"),
+				))
+				Expect(pqErr.Message).To(SatisfyAny(
+					MatchRegexp("authentication failed for user"),
+					MatchRegexp("role .* does not exist"),
+				))
 			})
 
 			It("CreateUser() returns the same user and different password", func() {

--- a/sqlengine/postgres_engine_test.go
+++ b/sqlengine/postgres_engine_test.go
@@ -187,6 +187,13 @@ var _ = Describe("PostgresEngine", func() {
 		Expect(err).To(HaveOccurred())
 	})
 
+	It("returns error LoginFailedError if the credentials are wrong", func() {
+		err := postgresEngine.Open(address, port, dbname, masterUsername, "wrong_password")
+		defer postgresEngine.Close()
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(LoginFailedError))
+	})
+
 	Describe("Concurrency", func() {
 
 		It("Should be able to handle rapid parallel CreateUser/DropUser from multiple connections", func() {


### PR DESCRIPTION
What?
----

We found out that the RDS broker was not updating the master password of the
mysql RDS instances when the seed or the algorithm changes. This is because
the corresponding engine was not raising the right error when there
was an authentication issue.

In this PR we add the logic to raise the right error for mysql and add unit
tests for this logic.

In order for the tests to work, we need to add authentication to the postgres
database used during testing, both in docker (local) or travis. The reason
is that postgres would accept any password when the authentication is disabled.
In travis the only way is by updating the database in a `before_script`.

With mysql there was not such problem, because a password different than `""` would fail. 

How to review?
--------------

 - Code review.
 - Tests shall pass.
 - Optional: Deploy the RDS broker, create a mysql and psql instance,
   try to change the seed and restart the broker.

Who?
----

Anyone but @keymon