### PR TITLE
[#156224236] Use DescribeDBInstancePages to list all RDS

### DIFF
--- a/awsrds/rds_db_instance.go
+++ b/awsrds/rds_db_instance.go
@@ -77,12 +77,18 @@ func (r *RDSDBInstance) DescribeByTag(tagKey, tagValue string) ([]*DBInstanceDet
 
 	describeDBInstancesInput := &rds.DescribeDBInstancesInput{}
 
-	dbInstances, err := r.rdssvc.DescribeDBInstances(describeDBInstancesInput)
+	var dbInstances []*rds.DBInstance
+	err := r.rdssvc.DescribeDBInstancesPages(describeDBInstancesInput,
+		func(page *rds.DescribeDBInstancesOutput, lastPage bool) bool {
+			dbInstances = append(dbInstances, page.DBInstances...)
+			return true
+		},
+	)
 
 	if err != nil {
 		return dbInstanceDetails, err
 	}
-	for _, dbInstance := range dbInstances.DBInstances {
+	for _, dbInstance := range dbInstances {
 		listTagsForResourceInput := &rds.ListTagsForResourceInput{
 			ResourceName: dbInstance.DBInstanceArn,
 		}


### PR DESCRIPTION
What?
-----

We use a paginated endpoint to retrieve the RDS instances, but that
only list the first 100 RDS instances. Because that, when reseting the
master password, if there are more than 100 instances,
we are only reseting some of them.

In this commit we use the Page by Page endpoint
DescribeDBInstancePages to retrieve all the instances.

How to review?
------

Code review

Who?
---

Not me