### PR TITLE
Try to drop username generated with MD5

### DIFF
--- a/sqlengine/mysql_engine.go
+++ b/sqlengine/mysql_engine.go
@@ -115,7 +115,20 @@ func (d *MySQLEngine) DropUser(bindingID string) error {
 	dropUserStatement := "DROP USER '" + username + "'@'%';"
 	d.logger.Debug("drop-user", lager.Data{"statement": dropUserStatement})
 
-	if _, err := d.db.Exec(dropUserStatement); err != nil {
+	_, err := d.db.Exec(dropUserStatement)
+	if err == nil {
+		return nil
+	}
+
+	// Try to drop the username generated the old way
+
+	username = generateUsernameOld(bindingID)
+
+	dropUserStatement = "DROP USER '" + username + "'@'%';"
+	d.logger.Debug("drop-user", lager.Data{"statement": dropUserStatement})
+
+	_, err = d.db.Exec(dropUserStatement)
+	if err != nil {
 		d.logger.Error("sql-error", err)
 		return err
 	}

--- a/sqlengine/sql_engine.go
+++ b/sqlengine/sql_engine.go
@@ -30,6 +30,11 @@ func generateUsername(seed string) string {
 	return "u" + strings.Replace(usernameString, "-", "_", -1)
 }
 
+func generateUsernameOld(seed string) string {
+	usernameString := strings.ToLower(utils.GetMD5B64(seed, usernameLength-1))
+	return "u" + strings.Replace(usernameString, "-", "_", -1)
+}
+
 func generatePassword() string {
 	return utils.RandomAlphaNum(passwordLength)
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"crypto/md5"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
@@ -45,6 +46,16 @@ func randChar(length int, chars []byte) string {
 func GenerateHash(text string, maxLength int) string {
 	hash := sha256.Sum256([]byte(text))
 	encoded := base64.URLEncoding.EncodeToString(hash[:])
+	if len(encoded) > maxLength {
+		return encoded[0:maxLength]
+	} else {
+		return encoded
+	}
+}
+
+func GetMD5B64(text string, maxLength int) string {
+	md5 := md5.Sum([]byte(text))
+	encoded := base64.URLEncoding.EncodeToString(md5[:])
 	if len(encoded) > maxLength {
 		return encoded[0:maxLength]
 	} else {


### PR DESCRIPTION
## What

We previously changed how we generate usernames and passwords (using SHA256 instead of MD5). But this change will cause any unbind for an existing binding to fail as the unbind tries to delete a different username (generated with SHA256 and not with MD5).

To fix this we will try to drop both the old username and the new username.

## How to review

Code review

## Who can review it

Not me.