### PR TITLE
Add a default retry of 3 times to AWS client

### DIFF
--- a/main.go
+++ b/main.go
@@ -71,7 +71,7 @@ func buildHTTPHandler(serviceBroker *rdsbroker.RDSBroker, logger lager.Logger, c
 }
 
 func buildDBInstance(region string, logger lager.Logger) awsrds.DBInstance {
-	awsConfig := aws.NewConfig().WithRegion(region)
+	awsConfig := aws.NewConfig().WithRegion(region).WithMaxRetries(3)
 	awsSession := session.New(awsConfig)
 	rdssvc := rds.New(awsSession)
 	return awsrds.NewRDSDBInstance(region, "aws", rdssvc, logger)


### PR DESCRIPTION
## What

We have occasionally received throttled responses from the AWS API. One
of thie suggestions was to add retrying into the client to avoid
showing errors to our users.

## How to review

Tests and code review

## Who can review

Not @LeePorte 