### PR TITLE
[#159620811] Allow properties to persist across master credentials rotation

### DIFF
--- a/awsrds/rds_db_instance.go
+++ b/awsrds/rds_db_instance.go
@@ -325,14 +325,20 @@ func (r *RDSDBInstance) Delete(ID string, skipFinalSnapshot bool) error {
 
 func (r *RDSDBInstance) buildDBInstance(dbInstance *rds.DBInstance) DBInstanceDetails {
 	dbInstanceDetails := DBInstanceDetails{
-		Identifier:       aws.StringValue(dbInstance.DBInstanceIdentifier),
-		Arn:              aws.StringValue(dbInstance.DBInstanceArn),
-		Status:           aws.StringValue(dbInstance.DBInstanceStatus),
-		Engine:           aws.StringValue(dbInstance.Engine),
-		EngineVersion:    aws.StringValue(dbInstance.EngineVersion),
-		DBName:           aws.StringValue(dbInstance.DBName),
-		MasterUsername:   aws.StringValue(dbInstance.MasterUsername),
-		AllocatedStorage: aws.Int64Value(dbInstance.AllocatedStorage),
+		Identifier:              aws.StringValue(dbInstance.DBInstanceIdentifier),
+		Arn:                     aws.StringValue(dbInstance.DBInstanceArn),
+		Status:                  aws.StringValue(dbInstance.DBInstanceStatus),
+		Engine:                  aws.StringValue(dbInstance.Engine),
+		EngineVersion:           aws.StringValue(dbInstance.EngineVersion),
+		DBName:                  aws.StringValue(dbInstance.DBName),
+		MasterUsername:          aws.StringValue(dbInstance.MasterUsername),
+		AllocatedStorage:        aws.Int64Value(dbInstance.AllocatedStorage),
+		AutoMinorVersionUpgrade: aws.BoolValue(dbInstance.AutoMinorVersionUpgrade),
+		BackupRetentionPeriod:   aws.Int64Value(dbInstance.BackupRetentionPeriod),
+		CopyTagsToSnapshot:      aws.BoolValue(dbInstance.CopyTagsToSnapshot),
+		MultiAZ:                 aws.BoolValue(dbInstance.MultiAZ),
+		PubliclyAccessible:      aws.BoolValue(dbInstance.PubliclyAccessible),
+		StorageEncrypted:        aws.BoolValue(dbInstance.StorageEncrypted),
 	}
 
 	if dbInstance.Endpoint != nil {

--- a/awsrds/rds_db_instance_test.go
+++ b/awsrds/rds_db_instance_test.go
@@ -82,14 +82,20 @@ var _ = Describe("RDS DB Instance", func() {
 			listTagsForResourceError = nil
 
 			describeDBInstance = &rds.DBInstance{
-				DBInstanceIdentifier: aws.String(dbInstanceIdentifier),
-				DBInstanceArn:        aws.String(dbInstanceArn),
-				DBInstanceStatus:     aws.String("available"),
-				Engine:               aws.String("test-engine"),
-				EngineVersion:        aws.String("1.2.3"),
-				DBName:               aws.String("test-dbname"),
-				MasterUsername:       aws.String("test-master-username"),
-				AllocatedStorage:     aws.Int64(100),
+				DBInstanceIdentifier:    aws.String(dbInstanceIdentifier),
+				DBInstanceArn:           aws.String(dbInstanceArn),
+				DBInstanceStatus:        aws.String("available"),
+				Engine:                  aws.String("test-engine"),
+				EngineVersion:           aws.String("1.2.3"),
+				DBName:                  aws.String("test-dbname"),
+				MasterUsername:          aws.String("test-master-username"),
+				AllocatedStorage:        aws.Int64(100),
+				AutoMinorVersionUpgrade: aws.Bool(true),
+				BackupRetentionPeriod:   aws.Int64(1),
+				CopyTagsToSnapshot:      aws.Bool(true),
+				MultiAZ:                 aws.Bool(true),
+				PubliclyAccessible:      aws.Bool(true),
+				StorageEncrypted:        aws.Bool(true),
 			}
 			describeDBInstancesInput = &rds.DescribeDBInstancesInput{
 				DBInstanceIdentifier: aws.String(dbInstanceIdentifier),
@@ -109,6 +115,12 @@ var _ = Describe("RDS DB Instance", func() {
 				MasterUsername:   "test-master-username",
 				AllocatedStorage: int64(100),
 				Tags:             listTags,
+				AutoMinorVersionUpgrade: true,
+				BackupRetentionPeriod:   int64(1),
+				CopyTagsToSnapshot:      true,
+				MultiAZ:                 true,
+				PubliclyAccessible:      true,
+				StorageEncrypted:        true,
 			}
 
 			rdssvc.Handlers.Clear()

--- a/ci/blackbox/config.json
+++ b/ci/blackbox/config.json
@@ -44,6 +44,7 @@
                             "name": "micro-without-snapshot",
                             "rds_properties": {
                                 "allocated_storage": 10,
+                                "auto_minor_version_upgrade": true,
                                 "db_instance_class": "db.t2.micro",
                                 "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
                                 "engine": "postgres",
@@ -89,6 +90,7 @@
                             "name": "micro-without-snapshot",
                             "rds_properties": {
                                 "allocated_storage": 10,
+                                "auto_minor_version_upgrade": true,
                                 "db_instance_class": "db.t2.micro",
                                 "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
                                 "engine": "mysql",

--- a/ci/helpers/rdsclient_helper.go
+++ b/ci/helpers/rdsclient_helper.go
@@ -19,9 +19,9 @@ func NewRDSClient(region string, dbPrefix string) (*RDSClient, error) {
 	sess := session.New(&aws.Config{Region: aws.String(region)})
 	rdssvc := rds.New(sess)
 	return &RDSClient{
-		region: region,
+		region:   region,
 		dbPrefix: dbPrefix,
-		rdssvc: rdssvc,
+		rdssvc:   rdssvc,
 	}, nil
 }
 
@@ -68,4 +68,12 @@ func (r *RDSClient) DeleteDBFinalSnapshot(ID string) (*rds.DeleteDBSnapshotOutpu
 		return nil, err
 	}
 	return resp, nil
+}
+
+func (r *RDSClient) GetDBInstanceDetails(ID string) (*rds.DescribeDBInstancesOutput, error) {
+	params := &rds.DescribeDBInstancesInput{
+		DBInstanceIdentifier: aws.String(r.dbInstanceIdentifier(ID)),
+	}
+
+	return r.rdssvc.DescribeDBInstances(params)
 }


### PR DESCRIPTION
What
----

Added copy operations for various properties associated with an RDS instance to avoid changing those properties by mistake during a master credentials rotation.

How to review
-------------

1. Code review
2. Unit & integration tests

Who can review
--------------

Not @blairboy362 or @keymon 