### PR TITLE
[#160176077] Fix bug with cached tags when restoring from snapshot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ unit:
 	POSTGRESQL_PASSWORD=$(POSTGRESQL_PASSWORD) ginkgo -r --skipPackage=ci
 
 integration:
-	ginkgo -p --nodes=8 -r ci/blackbox
+	ginkgo -p --nodes=16 -r ci/blackbox
 
 start_docker_dbs:
 	docker run -p 5432:5432 --name postgres -e POSTGRES_PASSWORD=$(POSTGRESQL_PASSWORD) -d postgres:9.5

--- a/awsrds/db_instance.go
+++ b/awsrds/db_instance.go
@@ -5,9 +5,16 @@ import (
 	"time"
 )
 
+type DescribeOption string
+
+const (
+	// Should Describe* ops invalidate and refresh the cache
+	DescribeRefreshCacheOption DescribeOption = "refreshCache"
+)
+
 type DBInstance interface {
-	Describe(ID string) (DBInstanceDetails, error)
-	DescribeByTag(TagName, TagValue string) ([]*DBInstanceDetails, error)
+	Describe(ID string, opts ...DescribeOption) (DBInstanceDetails, error)
+	DescribeByTag(TagName, TagValue string, opts ...DescribeOption) ([]*DBInstanceDetails, error)
 	DescribeSnapshots(DBInstanceID string) ([]*DBSnapshotDetails, error)
 	DeleteSnapshots(brokerName string, keepForDays int) error
 	Create(ID string, dbInstanceDetails DBInstanceDetails) error

--- a/awsrds/fakes/fake_db_instance.go
+++ b/awsrds/fakes/fake_db_instance.go
@@ -7,12 +7,14 @@ import (
 type FakeDBInstance struct {
 	DescribeCalled            bool
 	DescribeID                string
+	DescribeOpts              []awsrds.DescribeOption
 	DescribeDBInstanceDetails awsrds.DBInstanceDetails
 	DescribeError             error
 
 	DescribeByTagCalled            bool
 	DescribeByTagKey               string
 	DescribeByTagValue             string
+	DescribeByTagOpts              []awsrds.DescribeOption
 	DescribeByTagDBInstanceDetails []*awsrds.DBInstanceDetails
 	DescribeByTagError             error
 
@@ -63,9 +65,10 @@ type FakeDBInstance struct {
 	GetTagError error
 }
 
-func (f *FakeDBInstance) Describe(ID string) (awsrds.DBInstanceDetails, error) {
+func (f *FakeDBInstance) Describe(ID string, opts ...awsrds.DescribeOption) (awsrds.DBInstanceDetails, error) {
 	f.DescribeCalled = true
 	f.DescribeID = ID
+	f.DescribeOpts = opts
 
 	return f.DescribeDBInstanceDetails, f.DescribeError
 }
@@ -78,10 +81,11 @@ func (f *FakeDBInstance) GetTag(ID, tagKey string) (string, error) {
 	return f.GetTagValue, f.GetTagError
 }
 
-func (f *FakeDBInstance) DescribeByTag(tagKey, tagValue string) ([]*awsrds.DBInstanceDetails, error) {
+func (f *FakeDBInstance) DescribeByTag(tagKey, tagValue string, opts ...awsrds.DescribeOption) ([]*awsrds.DBInstanceDetails, error) {
 	f.DescribeByTagCalled = true
 	f.DescribeByTagKey = tagKey
 	f.DescribeByTagValue = tagValue
+	f.DescribeOpts = opts
 
 	return f.DescribeByTagDBInstanceDetails, f.DescribeByTagError
 }

--- a/awsrds/rds_db_instance_test.go
+++ b/awsrds/rds_db_instance_test.go
@@ -172,7 +172,7 @@ var _ = Describe("RDS DB Instance", func() {
 				Expect(dbInstanceDetails).To(Equal(properDBInstanceDetails))
 			})
 
-			It("caches the tags of an instance and only queries ListTagsForResource once per instance", func() {
+			It("caches the tags from ListTagsForResource unless DescribeRefreshCacheOption is passed", func() {
 				dbInstanceDetails, err := rdsDBInstance.Describe(dbInstanceIdentifier)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(dbInstanceDetails).To(Equal(properDBInstanceDetails))
@@ -182,8 +182,13 @@ var _ = Describe("RDS DB Instance", func() {
 				Expect(dbInstanceDetails).To(Equal(properDBInstanceDetails))
 
 				Expect(listTagsForResourceCallCount).To(Equal(1))
-			})
 
+				dbInstanceDetails, err = rdsDBInstance.Describe(dbInstanceIdentifier, DescribeRefreshCacheOption)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(dbInstanceDetails).To(Equal(properDBInstanceDetails))
+
+				Expect(listTagsForResourceCallCount).To(Equal(2))
+			})
 		})
 
 		Context("when RDS DB Instance has an Endpoint", func() {
@@ -463,16 +468,26 @@ var _ = Describe("RDS DB Instance", func() {
 			Expect(dbInstanceDetailsList).To(HaveLen(2))
 		})
 
-		It("caches the tags of an instance and only queries ListTagsForResource once per instance", func() {
+		It("caches the tags from ListTagsForResource unless DescribeRefreshCacheOption is passed", func() {
 			dbInstanceDetailsList, err := rdsDBInstance.DescribeByTag("Broker Name", "mybroker")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(dbInstanceDetailsList).To(HaveLen(2))
+
+			Expect(listTagsForResourceCallCount).To(Equal(len(describeDBInstances)))
 
 			dbInstanceDetailsList, err = rdsDBInstance.DescribeByTag("Broker Name", "mybroker")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(dbInstanceDetailsList).To(HaveLen(2))
 
 			Expect(listTagsForResourceCallCount).To(Equal(len(describeDBInstances)))
+
+			previousCount := listTagsForResourceCallCount
+
+			dbInstanceDetailsList, err = rdsDBInstance.DescribeByTag("Broker Name", "mybroker", DescribeRefreshCacheOption)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(dbInstanceDetailsList).To(HaveLen(2))
+
+			Expect(listTagsForResourceCallCount).To(Equal(previousCount + len(describeDBInstances)))
 		})
 	})
 

--- a/ci/blackbox/config.json
+++ b/ci/blackbox/config.json
@@ -28,6 +28,7 @@
                                 "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
                                 "engine": "postgres",
                                 "engine_version": "9.5",
+                                "copy_tags_to_snapshot":true,
                                 "vpc_security_group_ids": [
                                     "POPULATED_BY_TEST_SUITE"
                                 ],
@@ -50,6 +51,7 @@
                                 "engine": "postgres",
                                 "engine_version": "9.5",
                                 "skip_final_snapshot": true,
+                                "copy_tags_to_snapshot":true,
                                 "vpc_security_group_ids": [
                                     "POPULATED_BY_TEST_SUITE"
                                 ],
@@ -78,6 +80,7 @@
                                 "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
                                 "engine": "mysql",
                                 "engine_version": "5.7",
+                                "copy_tags_to_snapshot":true,
                                 "vpc_security_group_ids": [
                                     "POPULATED_BY_TEST_SUITE"
                                 ]
@@ -96,6 +99,7 @@
                                 "engine": "mysql",
                                 "engine_version": "5.7",
                                 "skip_final_snapshot": true,
+                                "copy_tags_to_snapshot":true,
                                 "vpc_security_group_ids": [
                                     "POPULATED_BY_TEST_SUITE"
                                 ]

--- a/ci/blackbox/integration_suite_test.go
+++ b/ci/blackbox/integration_suite_test.go
@@ -2,7 +2,9 @@ package integration_aws_test
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -28,6 +30,10 @@ var (
 func TestSuite(t *testing.T) {
 	BeforeSuite(func() {
 		var err error
+
+		// Randomly wait up to 30 seconds, to avoid Rate limiting from AWS when
+		// all tests start at the same time.
+		time.Sleep(time.Duration(rand.Intn(30)) * time.Second)
 
 		// Compile the broker
 		rdsBrokerPath, err = gexec.Build("github.com/alphagov/paas-rds-broker")

--- a/ci/blackbox/rdsbroker_test.go
+++ b/ci/blackbox/rdsbroker_test.go
@@ -207,13 +207,15 @@ var _ = Describe("RDS Broker Daemon", func() {
 			const planID = "micro"
 
 			var (
-				instanceID string
-				appGUID    string
-				bindingID  string
+				instanceID      string
+				finalSnapshotID string
+				appGUID         string
+				bindingID       string
 			)
 
 			BeforeEach(func() {
 				instanceID = uuid.NewV4().String()
+				finalSnapshotID = rdsClient.DBInstanceFinalSnapshotIdentifier(instanceID)
 				appGUID = uuid.NewV4().String()
 				bindingID = uuid.NewV4().String()
 				brokerAPIClient.AcceptsIncomplete = true
@@ -232,13 +234,13 @@ var _ = Describe("RDS Broker Daemon", func() {
 				state = pollForOperationCompletion(brokerAPIClient, instanceID, serviceID, planID, operation)
 				Expect(state).To(Equal("gone"))
 
-				snapshots, err := rdsClient.GetDBFinalSnapshots(instanceID)
+				snapshots, err := rdsClient.GetDBSnapshot(finalSnapshotID)
 				fmt.Fprintf(GinkgoWriter, "Final snapshots for %s:\n", instanceID)
 				fmt.Fprint(GinkgoWriter, snapshots)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(snapshots).Should(ContainSubstring(instanceID))
 
-				snapshotDeletionOutput, err := rdsClient.DeleteDBFinalSnapshot(instanceID)
+				snapshotDeletionOutput, err := rdsClient.DeleteDBSnapshot(finalSnapshotID)
 				fmt.Fprintf(GinkgoWriter, "Snapshot deletion output for %s:\n", instanceID)
 				fmt.Fprint(GinkgoWriter, snapshotDeletionOutput)
 				Expect(err).NotTo(HaveOccurred())
@@ -257,13 +259,13 @@ var _ = Describe("RDS Broker Daemon", func() {
 				state = pollForOperationCompletion(brokerAPIClient, instanceID, serviceID, planID, operation)
 				Expect(state).To(Equal("gone"))
 
-				snapshots, err := rdsClient.GetDBFinalSnapshots(instanceID)
+				snapshots, err := rdsClient.GetDBSnapshot(finalSnapshotID)
 				fmt.Fprintf(GinkgoWriter, "Final snapshots for %s:\n", instanceID)
 				fmt.Fprint(GinkgoWriter, snapshots)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).Should(ContainSubstring("DBSnapshotNotFound"))
 
-				snapshotDeletionOutput, err := rdsClient.DeleteDBFinalSnapshot(instanceID)
+				snapshotDeletionOutput, err := rdsClient.DeleteDBSnapshot(finalSnapshotID)
 				fmt.Fprintf(GinkgoWriter, "Snapshot deletion output for %s:\n", instanceID)
 				fmt.Fprint(GinkgoWriter, snapshotDeletionOutput)
 				Expect(err).To(HaveOccurred())
@@ -288,13 +290,13 @@ var _ = Describe("RDS Broker Daemon", func() {
 				state = pollForOperationCompletion(brokerAPIClient, instanceID, serviceID, planID, operation)
 				Expect(state).To(Equal("gone"))
 
-				snapshots, err := rdsClient.GetDBFinalSnapshots(instanceID)
+				snapshots, err := rdsClient.GetDBSnapshot(finalSnapshotID)
 				fmt.Fprintf(GinkgoWriter, "Final snapshots for %s:\n", instanceID)
 				fmt.Fprint(GinkgoWriter, snapshots)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).Should(ContainSubstring("DBSnapshotNotFound"))
 
-				snapshotDeletionOutput, err := rdsClient.DeleteDBFinalSnapshot(instanceID)
+				snapshotDeletionOutput, err := rdsClient.DeleteDBSnapshot(finalSnapshotID)
 				fmt.Fprintf(GinkgoWriter, "Snapshot deletion output for %s:\n", instanceID)
 				fmt.Fprint(GinkgoWriter, snapshotDeletionOutput)
 				Expect(err).To(HaveOccurred())

--- a/ci/helpers/provision_manager_helper.go
+++ b/ci/helpers/provision_manager_helper.go
@@ -1,0 +1,45 @@
+package helpers
+
+import "sync"
+
+type WaitFunc func()
+type CleanFunc func()
+type ProvisionFunc func() (WaitFunc, CleanFunc)
+
+// ProvisionManager performs the provisioning.
+// It gets  a Provisioner function that should do the creationg and
+// returns:
+//  - a function that would synchronously wait for the thing to finish
+//  - a function that would clean up whatever is created
+//
+// It allows to optionally wait for the creation to finish or cleanup only once.
+type ProvisionManager struct {
+	Provisioner   ProvisionFunc
+	cleaner       CleanFunc
+	wg            sync.WaitGroup
+	provisionOnce sync.Once
+	cleanupOnce   sync.Once
+}
+
+func (p *ProvisionManager) Provision() {
+	p.provisionOnce.Do(func() {
+		waitFunc, cleaner := p.Provisioner()
+		p.cleaner = cleaner
+		p.wg.Add(1)
+		go func() {
+			defer p.wg.Done()
+			waitFunc()
+		}()
+	})
+}
+
+func (p *ProvisionManager) Wait() {
+	p.wg.Wait()
+}
+
+func (p *ProvisionManager) CleanUp() {
+	p.Wait()
+	p.cleanupOnce.Do(func() {
+		p.cleaner()
+	})
+}

--- a/ci/helpers/rdsclient_helper.go
+++ b/ci/helpers/rdsclient_helper.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -33,6 +34,10 @@ func (b *RDSClient) dbInstanceIdentifierToServiceInstanceID(serviceInstanceID st
 	return strings.TrimPrefix(serviceInstanceID, strings.Replace(b.dbPrefix, "_", "-", -1)+"-")
 }
 
+func (b *RDSClient) DBInstanceFinalSnapshotIdentifier(instanceID string) string {
+	return b.dbInstanceIdentifier(instanceID) + "-final-snapshot"
+}
+
 func (r *RDSClient) Ping() (bool, error) {
 	params := &rds.DescribeDBEngineVersionsInput{}
 
@@ -44,9 +49,25 @@ func (r *RDSClient) Ping() (bool, error) {
 	return true, nil
 }
 
-func (r *RDSClient) GetDBFinalSnapshots(ID string) (*rds.DescribeDBSnapshotsOutput, error) {
+func (r *RDSClient) CreateDBSnapshot(ID string) (string, error) {
+	snapshotID := r.dbInstanceIdentifier(ID) + time.Now().Format("2006-01-02-15-04")
+
+	params := &rds.CreateDBSnapshotInput{
+		DBInstanceIdentifier: aws.String(r.dbInstanceIdentifier(ID)),
+		DBSnapshotIdentifier: aws.String(snapshotID),
+	}
+
+	_, err := r.rdssvc.CreateDBSnapshot(params)
+
+	if err != nil {
+		return snapshotID, err
+	}
+	return snapshotID, nil
+}
+
+func (r *RDSClient) GetDBSnapshot(snapshotID string) (*rds.DescribeDBSnapshotsOutput, error) {
 	params := &rds.DescribeDBSnapshotsInput{
-		DBSnapshotIdentifier: aws.String(r.dbInstanceIdentifier(ID) + "-final-snapshot"),
+		DBSnapshotIdentifier: aws.String(snapshotID),
 	}
 
 	resp, err := r.rdssvc.DescribeDBSnapshots(params)
@@ -57,9 +78,9 @@ func (r *RDSClient) GetDBFinalSnapshots(ID string) (*rds.DescribeDBSnapshotsOutp
 	return resp, nil
 }
 
-func (r *RDSClient) DeleteDBFinalSnapshot(ID string) (*rds.DeleteDBSnapshotOutput, error) {
+func (r *RDSClient) DeleteDBSnapshot(snapshotID string) (*rds.DeleteDBSnapshotOutput, error) {
 	params := &rds.DeleteDBSnapshotInput{
-		DBSnapshotIdentifier: aws.String(r.dbInstanceIdentifier(ID) + "-final-snapshot"),
+		DBSnapshotIdentifier: aws.String(snapshotID),
 	}
 
 	resp, err := r.rdssvc.DeleteDBSnapshot(params)

--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -437,7 +437,7 @@ func (b *RDSBroker) LastOperation(
 		instanceIDLogKey: instanceID,
 	})
 
-	dbInstanceDetails, err := b.dbInstance.Describe(b.dbInstanceIdentifier(instanceID))
+	dbInstanceDetails, err := b.dbInstance.Describe(b.dbInstanceIdentifier(instanceID), awsrds.DescribeRefreshCacheOption)
 	if err != nil {
 		if err == awsrds.ErrDBInstanceDoesNotExist {
 			err = brokerapi.ErrInstanceDoesNotExist

--- a/rdsbroker/broker_test.go
+++ b/rdsbroker/broker_test.go
@@ -2047,6 +2047,14 @@ var _ = Describe("RDS Broker", func() {
 				lastOperationState = brokerapi.InProgress
 			})
 
+			It("calls Describe() with the refresh cache option", func() {
+				lastOperationResponse, err := rdsBroker.LastOperation(ctx, instanceID, "")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(lastOperationResponse).To(Equal(properLastOperationResponse))
+
+				Expect(dbInstance.DescribeOpts).To(ContainElement(awsrds.DescribeRefreshCacheOption))
+			})
+
 			It("returns the proper LastOperationResponse", func() {
 				lastOperationResponse, err := rdsBroker.LastOperation(ctx, instanceID, "")
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
What?
-----

The restore from snapshot feature relies on the LastOperation broker endpoint
that will be called periodically by the API. That would read/update the
tags of the DB instance to implement a short of state machine to execute
the required steps to restore an instance from snapshot[1]

In [2] we added some caching logic to avoid querying the instance tags in
every Describe() operation, but that broke the previous mentioned feature.

In this PR we add a feature to override the cache of tags by passing an
option to the Describe*() methods, and change the LastOperation handler
to use it.

We add a new integration test for this feature. This test has to run in a sequence an instance creation, snapshot, and another instance creation, so it adds some time to all the acceptance tests. Now it would last ~24 minutes.  

[1] https://github.com/alphagov/paas-rds-broker/pull/35
[2] https://github.com/alphagov/paas-rds-broker/pull/83

How to review?
-------------

 - Code review
 - Check that the test pass
    - Integration test in verbose mode can be checked in: https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/rds-broker/jobs/integration-test/builds/239, it failed because it had a focus.

Who?
---

Not @keymon