### PR TITLE
[#160176077] Use SynchronizedBeforeSuite in integration test

### DIFF
--- a/ci/blackbox/rdsbroker_test.go
+++ b/ci/blackbox/rdsbroker_test.go
@@ -39,7 +39,7 @@ var _ = Describe("RDS Broker Daemon", func() {
 	)
 
 	BeforeEach(func() {
-		rdsBrokerSession, brokerAPIClient, rdsClient = startNewBroker(rdsBrokerConfig)
+		rdsBrokerSession, brokerAPIClient, rdsClient = startNewBroker(suiteData.RdsBrokerConfig)
 	})
 
 	AfterEach(func() {
@@ -147,9 +147,9 @@ var _ = Describe("RDS Broker Daemon", func() {
 
 				By("restarting the broker with a new master password seed")
 				rdsBrokerSession.Kill()
-				newRDSConfig := *rdsBrokerConfig.RDSConfig
+				newRDSConfig := *suiteData.RdsBrokerConfig.RDSConfig
 				newRDSConfig.MasterPasswordSeed = "otherseed"
-				newRDSBrokerConfig := *rdsBrokerConfig
+				newRDSBrokerConfig := *suiteData.RdsBrokerConfig
 				newRDSBrokerConfig.RDSConfig = &newRDSConfig
 				rdsBrokerSession, brokerAPIClient, rdsClient = startNewBroker(&newRDSBrokerConfig)
 
@@ -476,7 +476,7 @@ func startNewBroker(rdsBrokerConfig *config.Config) (*gexec.Session, *BrokerAPIC
 	Expect(ioutil.WriteFile(configFile.Name(), configJSON, 0644)).To(Succeed())
 	Expect(configFile.Close()).To(Succeed())
 
-	command := exec.Command(rdsBrokerPath,
+	command := exec.Command(suiteData.RdsBrokerPath,
 		fmt.Sprintf("-config=%s", configFile.Name()),
 	)
 	rdsBrokerSession, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)


### PR DESCRIPTION
What?
----

In the integration test we need to create some shared resources
before testing:
 - Build the binary
 - Create subnet group
 - Create security groups

We also want to run all the tests in parallel to speed up these
tests, as creating RDS instances is slow. If possible we want
to run all in parallel.

But using the normal AfterSuite/BeforeSuite methods for the creation
of the shared resources would run that in each node, not reusing
the resources.

To run a unique initialisation function in only one node we must
user SynchronizedBeforeSuite[1].

We refactor the suite for that, with two functions: one to
create the shared resources that only runs on the 1st node. Other
to read the shared data from the 1st functions in all the other
nodes (the nodes do not share memory).

We only need to share the path of the binary of rds-broker and
the generated configuration.

[1] https://godoc.org/github.com/onsi/ginkgo#SynchronizedBeforeSuite

How to review?
-------------
 - Code review
 - Integration test should pass OK in CI

Who?
----
not me