### PR TITLE
WIP: [#159846052] Fix integration tests to actually test mysql

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ unit:
 	POSTGRESQL_PASSWORD=$(POSTGRESQL_PASSWORD) ginkgo -r --skipPackage=ci
 
 integration:
-	ginkgo -p --nodes=16 -r ci/blackbox
+	ginkgo -v ci/blackbox
 
 start_docker_dbs:
 	docker run -p 5432:5432 --name postgres -e POSTGRES_PASSWORD=$(POSTGRESQL_PASSWORD) -d postgres:9.5

--- a/ci/blackbox/config.json
+++ b/ci/blackbox/config.json
@@ -20,7 +20,7 @@
                         {
                             "description": "Micro plan",
                             "free": false,
-                            "id": "micro",
+                            "id": "postgres-micro",
                             "name": "micro",
                             "rds_properties": {
                                 "allocated_storage": 10,
@@ -41,7 +41,7 @@
                         {
                             "description": "Micro plan without final snapshot",
                             "free": false,
-                            "id": "micro-without-snapshot",
+                            "id": "postgres-micro-without-snapshot",
                             "name": "micro-without-snapshot",
                             "rds_properties": {
                                 "allocated_storage": 10,
@@ -72,7 +72,7 @@
                         {
                             "description": "Micro plan",
                             "free": false,
-                            "id": "micro",
+                            "id": "mysql-micro",
                             "name": "micro",
                             "rds_properties": {
                                 "allocated_storage": 10,
@@ -89,7 +89,7 @@
                         {
                             "description": "Micro plan without final snapshot",
                             "free": false,
-                            "id": "micro-without-snapshot",
+                            "id": "mysql-micro-without-snapshot",
                             "name": "micro-without-snapshot",
                             "rds_properties": {
                                 "allocated_storage": 10,

--- a/ci/blackbox/rdsbroker_test.go
+++ b/ci/blackbox/rdsbroker_test.go
@@ -198,7 +198,7 @@ var _ = Describe("RDS Broker Daemon", func() {
 			TestProvisionBindDeprovision("postgres")
 		})
 
-		Describe("MySQL", func() {
+		FDescribe("MySQL", func() {
 			TestProvisionBindDeprovision("mysql")
 		})
 	})
@@ -421,7 +421,7 @@ var _ = Describe("RDS Broker Daemon", func() {
 			})
 		}
 
-		Describe("Postgres", func() {
+		FDescribe("Postgres", func() {
 			TestRestoreFromSnapshot("postgres")
 		})
 

--- a/ci/blackbox/rdsbroker_test.go
+++ b/ci/blackbox/rdsbroker_test.go
@@ -78,7 +78,7 @@ var _ = Describe("RDS Broker Daemon", func() {
 	Describe("Instance Provision/Bind/Deprovision and MasterPasswordSeed update", func() {
 
 		TestProvisionBindDeprovision := func(serviceID string) {
-			const planID = "micro-without-snapshot"
+			var planID = serviceID + "-micro-without-snapshot"
 
 			var (
 				instanceID string
@@ -205,7 +205,7 @@ var _ = Describe("RDS Broker Daemon", func() {
 
 	Describe("Final snapshot enable/disable", func() {
 		TestFinalSnapshot := func(serviceID string) {
-			const planID = "micro"
+			var planID = serviceID + "-micro"
 
 			var (
 				instanceID      string
@@ -315,7 +315,7 @@ var _ = Describe("RDS Broker Daemon", func() {
 
 	Describe("Restore from snapshot", func() {
 		TestRestoreFromSnapshot := func(serviceID string) {
-			const planID = "micro"
+			var planID = serviceID + "-micro"
 
 			var (
 				instanceID         string

--- a/ci/blackbox/rdsbroker_test.go
+++ b/ci/blackbox/rdsbroker_test.go
@@ -425,7 +425,7 @@ var _ = Describe("RDS Broker Daemon", func() {
 			TestRestoreFromSnapshot("postgres")
 		})
 
-		Describe("MySQL", func() {
+		PDescribe("MySQL", func() {
 			TestRestoreFromSnapshot("mysql")
 		})
 	})

--- a/ci/blackbox/rdsbroker_test.go
+++ b/ci/blackbox/rdsbroker_test.go
@@ -524,7 +524,7 @@ func openConnection(databaseURI string) (*sql.DB, error) {
 	case "postgres":
 		dsn = dbURL.String()
 	case "mysql":
-		dsn = fmt.Sprintf("%s@tcp(%s)%s?tls=true",
+		dsn = fmt.Sprintf("%s@tcp(%s)%s?tls=skip-verify",
 			dbURL.User.String(),
 			dbURL.Host,
 			dbURL.EscapedPath(),


### PR DESCRIPTION
What?
--------

In the integration tests we were using a example configuration file
which had the same `id` for the plans in MySQL and Postgres.

But how the broker is implemented, these IDs must be unique, otherwise
only the first ones would be taken into account.

In our case it resulted on the integration test not testing for mysql,
only twice for postgres.

We also disable the test to restore from snapshot in MySQL: We did not yet completely implemented the feature to restore from snapshot for MySQL, as we still need to implement the PostRestore steps.

How to review?
-----------------

 - Code review
 - Test should pass

Who?
---- 
Not me
