### PR TITLE
[#162475628] Implement reboot as a update operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,13 @@ Depending on the [broker configuration](https://github.com/alphagov/paas-rds-bro
 
 Provision calls support the following optional [arbitrary parameters](https://docs.cloudfoundry.org/devguide/services/managing-services.html#arbitrary-params-create):
 
-| Option                       | Type    | Description
-|:-----------------------------|:------- |:-----------
-| backup_retention_period      | Integer | The number of days that Amazon RDS should retain automatic backups of the DB instance (between `0` and `35`) (*)
-| character_set_name           | String  | For supported engines, indicates that the DB instance should be associated with the specified CharacterSet (*)
-| dbname                       | String  | The name of the Database to be provisioned. If it does not exists, the broker will create it, otherwise, it will reuse the existing one. If this parameter is not set, the broker will use a random Database name
-| preferred_backup_window      | String  | The daily time range during which automated backups are created if automated backups are enabled (*)
-| preferred_maintenance_window | String  | The weekly time range during which system maintenance can occur (*)
+| Option                         | Type    | Description
+|:-------------------------------|:------- |:-----------
+| `backup_retention_period`      | Integer | The number of days that Amazon RDS should retain automatic backups of the DB instance (between `0` and `35`) (*)
+| `character_set_name`           | String  | For supported engines, indicates that the DB instance should be associated with the specified CharacterSet (*)
+| `dbname`                       | String  | The name of the Database to be provisioned. If it does not exists, the broker will create it, otherwise, it will reuse the existing one. If this parameter is not set, the broker will use a random Database name
+| `preferred_backup_window`      | String  | The daily time range during which automated backups are created if automated backups are enabled (*)
+| `preferred_maintenance_window` | String  | The weekly time range during which system maintenance can occur (*)
 
 (*) Refer to the [Amazon Relational Database Service Documentation](https://aws.amazon.com/documentation/rds/) for more details about how to set these properties
 
@@ -81,14 +81,23 @@ Provision calls support the following optional [arbitrary parameters](https://do
 
 Update calls support the following optional [arbitrary parameters](https://docs.cloudfoundry.org/devguide/services/managing-services.html#arbitrary-params-update):
 
-| Option                       | Type    | Description
-|:-----------------------------|:------- |:-----------
-| apply_at_maintenance_window  | Boolean | Specifies whether the modifications in this request and any pending modifications are asynchronously applied as soon as possible (default) or if they should be queued until the Preferred Maintenance Window setting for the DB instance (*)
-| backup_retention_period      | Integer | The number of days that Amazon RDS should retain automatic backups of the DB instance (between `0` and `35`) (*)
-| preferred_backup_window      | String  | The daily time range during which automated backups are created if automated backups are enabled (*)
-| preferred_maintenance_window | String  | The weekly time range during which system maintenance can occur (*)
+| Option                         | Type    | Description
+|:-------------------------------|:------- |:-----------
+| `apply_at_maintenance_window`  | Boolean | Specifies whether the modifications in this request and any pending modifications are asynchronously applied as soon as possible (default) or if they should be queued until the Preferred Maintenance Window setting for the DB instance (*)
+| `backup_retention_period`      | Integer | The number of days that Amazon RDS should retain automatic backups of the DB instance (between `0` and `35`) (*)
+| `preferred_backup_window`      | String  | The daily time range during which automated backups are created if automated backups are enabled (*)
+| `preferred_maintenance_window` | String  | The weekly time range during which system maintenance can occur (*)
+| `preferred_maintenance_window` | String  | The weekly time range during which system maintenance can occur (*)
+| `reboot`                       | Boolean | Reboot the instance immediately. Any other parameter or change in the updated would be ignored. See https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_RebootInstance.html for detais.
+| `force_failover`               | Boolean | For HA failover during reboot. Only valid when used with `reboot` and for HA plans. See https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_RebootInstance.html for detais.
 
 (*) Refer to the [Amazon Relational Database Service Documentation](https://aws.amazon.com/documentation/rds/) for more details about how to set these properties
+
+#### Reboot
+
+Reboot is performed by passing the custom parameter `{ "reboot": true }` in an update. Pass `{ "reboot": true, "force_failover": true }` to force failover in a HA instance.
+
+It will not update the instance, so the new plan or custom parameters would be ignored.
 
 ### Housekeeping tasks
 

--- a/awsrds/db_instance.go
+++ b/awsrds/db_instance.go
@@ -25,7 +25,7 @@ type RDSInstance interface {
 	Restore(restoreRBInstanceInput *rds.RestoreDBInstanceFromDBSnapshotInput) error
 	Modify(modifyDBInstanceInput *rds.ModifyDBInstanceInput) (*rds.DBInstance, error)
 	AddTagsToResource(resourceArn string, tags []*rds.Tag) error
-	Reboot(ID string) error
+	Reboot(rebootDBInstanceInput *rds.RebootDBInstanceInput) error
 	RemoveTag(ID, tagKey string) error
 	Delete(ID string, skipFinalSnapshot bool) error
 	GetTag(ID, tagKey string) (string, error)

--- a/awsrds/fakes/fake_rds_instance.go
+++ b/awsrds/fakes/fake_rds_instance.go
@@ -123,10 +123,10 @@ type FakeRDSInstance struct {
 	addTagsToResourceReturnsOnCall map[int]struct {
 		result1 error
 	}
-	RebootStub        func(ID string) error
+	RebootStub        func(rebootDBInstanceInput *rds.RebootDBInstanceInput) error
 	rebootMutex       sync.RWMutex
 	rebootArgsForCall []struct {
-		ID string
+		rebootDBInstanceInput *rds.RebootDBInstanceInput
 	}
 	rebootReturns struct {
 		result1 error
@@ -633,16 +633,16 @@ func (fake *FakeRDSInstance) AddTagsToResourceReturnsOnCall(i int, result1 error
 	}{result1}
 }
 
-func (fake *FakeRDSInstance) Reboot(ID string) error {
+func (fake *FakeRDSInstance) Reboot(rebootDBInstanceInput *rds.RebootDBInstanceInput) error {
 	fake.rebootMutex.Lock()
 	ret, specificReturn := fake.rebootReturnsOnCall[len(fake.rebootArgsForCall)]
 	fake.rebootArgsForCall = append(fake.rebootArgsForCall, struct {
-		ID string
-	}{ID})
-	fake.recordInvocation("Reboot", []interface{}{ID})
+		rebootDBInstanceInput *rds.RebootDBInstanceInput
+	}{rebootDBInstanceInput})
+	fake.recordInvocation("Reboot", []interface{}{rebootDBInstanceInput})
 	fake.rebootMutex.Unlock()
 	if fake.RebootStub != nil {
-		return fake.RebootStub(ID)
+		return fake.RebootStub(rebootDBInstanceInput)
 	}
 	if specificReturn {
 		return ret.result1
@@ -656,10 +656,10 @@ func (fake *FakeRDSInstance) RebootCallCount() int {
 	return len(fake.rebootArgsForCall)
 }
 
-func (fake *FakeRDSInstance) RebootArgsForCall(i int) string {
+func (fake *FakeRDSInstance) RebootArgsForCall(i int) *rds.RebootDBInstanceInput {
 	fake.rebootMutex.RLock()
 	defer fake.rebootMutex.RUnlock()
-	return fake.rebootArgsForCall[i].ID
+	return fake.rebootArgsForCall[i].rebootDBInstanceInput
 }
 
 func (fake *FakeRDSInstance) RebootReturns(result1 error) {

--- a/awsrds/rds_db_instance.go
+++ b/awsrds/rds_db_instance.go
@@ -311,11 +311,7 @@ func (r *RDSDBInstance) AddTagsToResource(resourceARN string, tags []*rds.Tag) e
 	return nil
 }
 
-func (r *RDSDBInstance) Reboot(ID string) error {
-	rebootDBInstanceInput := &rds.RebootDBInstanceInput{
-		DBInstanceIdentifier: aws.String(ID),
-	}
-
+func (r *RDSDBInstance) Reboot(rebootDBInstanceInput *rds.RebootDBInstanceInput) error {
 	r.logger.Debug("reboot-db-instance", lager.Data{"input": rebootDBInstanceInput})
 
 	rebootDBInstanceOutput, err := r.rdssvc.RebootDBInstance(rebootDBInstanceInput)

--- a/awsrds/rds_db_instance_test.go
+++ b/awsrds/rds_db_instance_test.go
@@ -849,7 +849,9 @@ var _ = Describe("RDS DB Instance", func() {
 		})
 
 		It("does not return error", func() {
-			err := rdsDBInstance.Reboot(dbInstanceIdentifier)
+			err := rdsDBInstance.Reboot(&rds.RebootDBInstanceInput{
+				DBInstanceIdentifier: aws.String(dbInstanceIdentifier),
+			})
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -859,7 +861,9 @@ var _ = Describe("RDS DB Instance", func() {
 			})
 
 			It("returns the proper error", func() {
-				err := rdsDBInstance.Reboot(dbInstanceIdentifier)
+				err := rdsDBInstance.Reboot(&rds.RebootDBInstanceInput{
+					DBInstanceIdentifier: aws.String(dbInstanceIdentifier),
+				})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("operation failed"))
 			})
@@ -871,7 +875,9 @@ var _ = Describe("RDS DB Instance", func() {
 				})
 
 				It("returns the proper error", func() {
-					err := rdsDBInstance.Reboot(dbInstanceIdentifier)
+					err := rdsDBInstance.Reboot(&rds.RebootDBInstanceInput{
+						DBInstanceIdentifier: aws.String(dbInstanceIdentifier),
+					})
 					Expect(err).To(HaveOccurred())
 					Expect(err).To(Equal(ErrDBInstanceDoesNotExist))
 				})

--- a/awsrds/utils.go
+++ b/awsrds/utils.go
@@ -77,7 +77,7 @@ func HandleAWSError(err error, logger lager.Logger) error {
 	return err
 }
 
-func GetDBPort(endpoint *rds.Endpoint) (int64) {
+func GetDBPort(endpoint *rds.Endpoint) int64 {
 	if endpoint == nil {
 		return 0
 	} else {
@@ -92,4 +92,3 @@ func GetDBAddress(endpoint *rds.Endpoint) (dbAddress string) {
 		return aws.StringValue(endpoint.Address)
 	}
 }
-

--- a/ci/helpers/aws_helper.go
+++ b/ci/helpers/aws_helper.go
@@ -82,7 +82,6 @@ func CreateSecurityGroup(prefix string, session *session.Session) (*string, erro
 		}
 	}
 
-
 	return securityGroup.GroupId, nil
 }
 

--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -795,11 +795,11 @@ func (b *RDSBroker) createDBInstance(instanceID string, servicePlan ServicePlan,
 		LicenseModel:               servicePlan.RDSProperties.LicenseModel,
 		MultiAZ:                    servicePlan.RDSProperties.MultiAZ,
 		Port:                       servicePlan.RDSProperties.Port,
-		PreferredBackupWindow: servicePlan.RDSProperties.PreferredBackupWindow,
-		StorageEncrypted:      servicePlan.RDSProperties.StorageEncrypted,
-		StorageType:           servicePlan.RDSProperties.StorageType,
-		VpcSecurityGroupIds:   servicePlan.RDSProperties.VpcSecurityGroupIds,
-		Tags:                  awsrds.BuilRDSTags(b.dbTags("Created", details.ServiceID, details.PlanID, details.OrganizationGUID, details.SpaceGUID, skipFinalSnapshotStr, "")),
+		PreferredBackupWindow:      servicePlan.RDSProperties.PreferredBackupWindow,
+		StorageEncrypted:           servicePlan.RDSProperties.StorageEncrypted,
+		StorageType:                servicePlan.RDSProperties.StorageType,
+		VpcSecurityGroupIds:        servicePlan.RDSProperties.VpcSecurityGroupIds,
+		Tags:                       awsrds.BuilRDSTags(b.dbTags("Created", details.ServiceID, details.PlanID, details.OrganizationGUID, details.SpaceGUID, skipFinalSnapshotStr, "")),
 	}
 }
 

--- a/rdsbroker/parameters.go
+++ b/rdsbroker/parameters.go
@@ -16,6 +16,8 @@ type UpdateParameters struct {
 	PreferredBackupWindow      string `json:"preferred_backup_window"`
 	PreferredMaintenanceWindow string `json:"preferred_maintenance_window"`
 	SkipFinalSnapshot          *bool  `json:"skip_final_snapshot"`
+	Reboot                     *bool  `json:"reboot"`
+	ForceFailover              *bool  `json:"force_failover"`
 }
 
 type BindParameters struct {


### PR DESCRIPTION
What?
----

We want to enable the tenants to trigger a instance reboot if they
desire. We implement the option to reboot the instance by accepting
custom update parameters.

The reboot must be used alone, and any update option passed will
make the update fail.

How to review?
--------------

Code review


Who?
----

Not me