### PR TITLE
[#163084103] Prevent setting unknown properties on MySQL parameter groups

### DIFF
--- a/rdsbroker/parameter_groups_source_test.go
+++ b/rdsbroker/parameter_groups_source_test.go
@@ -228,6 +228,18 @@ var _ = Describe("ParameterGroupsSource", func() {
 			})
 
 			Describe("it modifies the created parameter group", func() {
+				It("does not make any changes to the parameter group for MySQL databases", func() {
+					servicePlan.RDSProperties.Engine = aws.String("mysql")
+					servicePlan.RDSProperties.EngineVersion = aws.String("5.7")
+					servicePlan.RDSProperties.EngineFamily = aws.String("mysql5.7")
+
+					rdsFake.ModifyParameterGroupReturns(nil)
+
+					parameterGroupSource.SelectParameterGroup(servicePlan, provisionDetails)
+
+					Expect(rdsFake.ModifyParameterGroupCallCount()).To(Equal(0), "ModifyParameterGroup was called when it shouldn't have been")
+				})
+
 				It("and sets the force SSL property", func() {
 					rdsFake.ModifyParameterGroupReturns(nil)
 


### PR DESCRIPTION
# What
The `rds.force_ssl` and `rds.log_retention_period` parameters are not known by MySQL RDS parameter groups. Setting them would result in failure the first time a parameter group was used but, because of when parameter groups are modified, would not cause any errors in future uses.

This PR prevents those parameters being set for MySQL groups.

# How to review
Code review should be enough

# Who can review
Not me