### PR TITLE
[#163084103] Actually integration test MySQL

### DIFF
--- a/ci/blackbox/config.json
+++ b/ci/blackbox/config.json
@@ -20,7 +20,7 @@
                         {
                             "description": "Micro plan",
                             "free": false,
-                            "id": "micro",
+                            "id": "postgres-micro",
                             "name": "micro",
                             "rds_properties": {
                                 "allocated_storage": 10,
@@ -48,7 +48,7 @@
                         {
                             "description": "Micro plan without final snapshot",
                             "free": false,
-                            "id": "micro-without-snapshot",
+                            "id": "postgres-micro-without-snapshot",
                             "name": "micro-without-snapshot",
                             "rds_properties": {
                                 "allocated_storage": 10,
@@ -78,7 +78,7 @@
                         {
                             "description": "Micro plan - Postgres 10",
                             "free": false,
-                            "id": "micro-10",
+                            "id": "postgres-micro-10",
                             "name": "micro-10",
                             "rds_properties": {
                                 "allocated_storage": 10,
@@ -108,7 +108,7 @@
                         {
                             "description": "Micro plan without final snapshot - Postgres 10",
                             "free": false,
-                            "id": "micro-without-snapshot-10",
+                            "id": "postgres-micro-without-snapshot-10",
                             "name": "micro-without-snapshot-10",
                             "rds_properties": {
                                 "allocated_storage": 10,
@@ -148,7 +148,7 @@
                         {
                             "description": "Micro plan",
                             "free": false,
-                            "id": "micro",
+                            "id": "mysql-micro",
                             "name": "micro",
                             "rds_properties": {
                                 "allocated_storage": 10,
@@ -166,7 +166,7 @@
                         {
                             "description": "Micro plan without final snapshot",
                             "free": false,
-                            "id": "micro-without-snapshot",
+                            "id": "mysql-micro-without-snapshot",
                             "name": "micro-without-snapshot",
                             "rds_properties": {
                                 "allocated_storage": 10,

--- a/ci/blackbox/rdsbroker_test.go
+++ b/ci/blackbox/rdsbroker_test.go
@@ -538,7 +538,7 @@ func openConnection(databaseURI string) (*sql.DB, error) {
 	case "postgres":
 		dsn = dbURL.String()
 	case "mysql":
-		dsn = fmt.Sprintf("%s@tcp(%s)%s?tls=true",
+		dsn = fmt.Sprintf("%s@tcp(%s)%s?tls=skip-verify",
 			dbURL.User.String(),
 			dbURL.Host,
 			dbURL.EscapedPath(),

--- a/ci/blackbox/rdsbroker_test.go
+++ b/ci/blackbox/rdsbroker_test.go
@@ -202,15 +202,15 @@ var _ = Describe("RDS Broker Daemon", func() {
 		}
 
 		Describe("Postgres 9.5", func() {
-			TestProvisionBindDeprovision("postgres", "micro-without-snapshot")
+			TestProvisionBindDeprovision("postgres", "postgres-micro-without-snapshot")
 		})
 
 		Describe("Postgres 10.5", func() {
-			TestProvisionBindDeprovision("postgres", "micro-without-snapshot-10")
+			TestProvisionBindDeprovision("postgres", "postgres-micro-without-snapshot-10")
 		})
 
 		Describe("MySQL", func() {
-			TestProvisionBindDeprovision("mysql", "micro-without-snapshot")
+			TestProvisionBindDeprovision("mysql", "mysql-micro-without-snapshot")
 		})
 	})
 
@@ -310,15 +310,15 @@ var _ = Describe("RDS Broker Daemon", func() {
 		}
 
 		Describe("Postgres 9.5", func() {
-			TestFinalSnapshot("postgres", "micro")
+			TestFinalSnapshot("postgres", "postgres-micro")
 		})
 
 		Describe("Postgres 10.5", func() {
-			TestFinalSnapshot("postgres", "micro-10")
+			TestFinalSnapshot("postgres", "postgres-micro-10")
 		})
 
 		Describe("MySQL", func() {
-			TestFinalSnapshot("mysql", "micro")
+			TestFinalSnapshot("mysql", "mysql-micro")
 		})
 	})
 
@@ -429,15 +429,15 @@ var _ = Describe("RDS Broker Daemon", func() {
 		}
 
 		Describe("Postgres 9.5", func() {
-			TestRestoreFromSnapshot("postgres", "micro")
+			TestRestoreFromSnapshot("postgres", "postgres-micro")
 		})
 
 		Describe("Postgres 10.5", func() {
-			TestRestoreFromSnapshot("postgres", "micro-10")
+			TestRestoreFromSnapshot("postgres", "postgres-micro-10")
 		})
 
 		Describe("MySQL", func() {
-			TestRestoreFromSnapshot("mysql", "micro")
+			TestRestoreFromSnapshot("mysql", "mysql-micro")
 		})
 	})
 

--- a/ci/blackbox/rdsbroker_test.go
+++ b/ci/blackbox/rdsbroker_test.go
@@ -436,7 +436,7 @@ var _ = Describe("RDS Broker Daemon", func() {
 			TestRestoreFromSnapshot("postgres", "postgres-micro-10")
 		})
 
-		Describe("MySQL", func() {
+		PDescribe("MySQL", func() {
 			TestRestoreFromSnapshot("mysql", "mysql-micro")
 		})
 	})


### PR DESCRIPTION
# What
Service plans require a globally unique ID, but the integration test config had the same plan id's for both MySQL and Postgres, which resulted in tests marked as testing MySQL picking a Postgres plan. 

This PR gives them suitably unique ids.

# How to review
1. Code review
2. Ensure integration tests passed. To make sure it's actually testing MySQL, you could check for MySQL instances being created in RDS in the CI account during the lifetime of the tests.

# Who can review
Anyone