### PR TITLE
[#164987516] Add in extensions that require shared library preload

### DIFF
--- a/rdsbroker/supported_extensions.go
+++ b/rdsbroker/supported_extensions.go
@@ -11,14 +11,50 @@ type DBExtension struct {
 var SupportedPreloadExtensions = map[string][]DBExtension{
 	"postgres10": {
 		DBExtension{
+			Name:                   "auto_explain",
+			RequiresPreloadLibrary: true,
+		},
+		DBExtension{
+			Name:                   "orafce",
+			RequiresPreloadLibrary: true,
+		},
+		DBExtension{
+			Name:                   "pgaudit",
+			RequiresPreloadLibrary: true,
+		},
+		DBExtension{
+			Name:                   "pglogical",
+			RequiresPreloadLibrary: true,
+		},
+		DBExtension{
+			Name:                   "pg_similarity",
+			RequiresPreloadLibrary: true,
+		},
+		DBExtension{
 			Name:                   "pg_stat_statements",
+			RequiresPreloadLibrary: true,
+		},
+		DBExtension{
+			Name:                   "pg_hint_plan",
 			RequiresPreloadLibrary: true,
 		},
 	},
 
 	"postgres9.5": {
 		DBExtension{
+			Name:                   "auto_explain",
+			RequiresPreloadLibrary: true,
+		},
+		DBExtension{
+			Name:                   "pgaudit",
+			RequiresPreloadLibrary: true,
+		},
+		DBExtension{
 			Name:                   "pg_stat_statements",
+			RequiresPreloadLibrary: true,
+		},
+		DBExtension{
+			Name:                   "pg_hint_plan",
 			RequiresPreloadLibrary: true,
 		},
 	},


### PR DESCRIPTION
As we are enabling all extensions, there are a few libraries that need to have shared preload enabled. This commit adds them in.