### PR TITLE
cflinuxfs2 -> cflinuxfs3, stop using obsolete `buildpack`

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,7 +2,9 @@ applications:
   - name: rds-broker
     memory: 256M
     disk_quota: 256M
-    buildpack: go_buildpack
+    buildpack: 
+    - go_buildpack
+    stack: cflinuxfs3
     env:
       AWS_ACCESS_KEY_ID: "your-aws-access-key-id"
       AWS_SECRET_ACCESS_KEY: "your-aws-secret-access-key"


### PR DESCRIPTION
* Explicitly move to the stack that's still supported.
* Use `buildpacks:` instead of `buildpack:`, which is deprecated