### PR TITLE
Remove manifest & docs pertaining to deploy via CF

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,22 +20,6 @@ $ go install github.com/alphagov/paas-rds-broker
 $ rds-broker -config=<path-to-your-config-file>
 ```
 
-### Cloud Foundry
-
-The broker can be deployed to an already existing [Cloud Foundry](https://www.cloudfoundry.org/) installation:
-
-```
-$ git clone https://github.com/alphagov/paas-rds-broker.git
-$ cd rds-broker
-```
-
-Modify the [included manifest file](https://github.com/alphagov/paas-rds-broker/blob/master/manifest.yml) to include your AWS credentials and optionally the [sample configuration file](https://github.com/alphagov/paas-rds-broker/blob/master/config-sample.json). Then you can push the broker to your [Cloud Foundry](https://www.cloudfoundry.org/) environment:
-
-```
-$ cp config-sample.json config.json
-$ cf push rds-broker
-```
-
 ### BOSH
 
 This broker can be deployed using the [AWS Service Broker BOSH Release](https://github.com/cf-platform-eng/aws-broker-boshrelease).

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,8 +1,0 @@
-applications:
-  - name: rds-broker
-    memory: 256M
-    disk_quota: 256M
-    buildpack: go_buildpack
-    env:
-      AWS_ACCESS_KEY_ID: "your-aws-access-key-id"
-      AWS_SECRET_ACCESS_KEY: "your-aws-secret-access-key"


### PR DESCRIPTION
We do not use cloud foundry to deploy the RDS broker, so we do not need
the manifest or to document its use

Closes #103