### PR TITLE
[#168322475] Tests for mysql 8 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,24 @@
-.PHONY: unit integration run_unit run_sql_tests start_postgres_9 start_postgres_10 stop_postgres_9 stop_postgres_10 start_mysql stop_mysql stop_dbs
+.PHONY: unit integration test_unit test_all_sql start_postgres_9 start_postgres_10 stop_postgres_9 stop_postgres_10 start_mysql_57 stop_mysql_57 start_mysql_80 stop_mysql_80 stop_dbs
 
 POSTGRESQL_PASSWORD=abc123
+MYSQL_PASSWORD=toor
 
 integration:
 	ginkgo -p --nodes=9 -r ci/blackbox --slowSpecThreshold=900 -stream
 
-unit: start_postgres_9 start_mysql run_unit stop_postgres_9 start_postgres_10 run_sql_tests stop_postgres_10 stop_mysql
+unit: test_unit test_all_sql
 
-run_unit:
-	POSTGRESQL_PASSWORD=$(POSTGRESQL_PASSWORD) ginkgo -r --skipPackage=ci
+test_unit:
+	ginkgo -r --skipPackage=ci,sqlengine
+test_all_sql: test_postgres test_mysql
+test_mysql: start_mysql_80 run_mysql_sql_tests stop_mysql_80 start_mysql_57 run_mysql_sql_tests stop_mysql_57
+test_postgres: start_postgres_9 run_postgres_sql_tests stop_postgres_9 start_postgres_10 run_postgres_sql_tests stop_postgres_10
 
-run_sql_tests:
-	POSTGRESQL_PASSWORD=$(POSTGRESQL_PASSWORD) ginkgo sqlengine/
+run_mysql_sql_tests:
+	MYSQL_PASSWORD=$(MYSQL_PASSWORD) ginkgo -focus=MySQLEngine.* sqlengine/
+
+run_postgres_sql_tests:
+	POSTGRESQL_PASSWORD=$(POSTGRESQL_PASSWORD) ginkgo -focus=PostgresEngine.* sqlengine/
 
 start_postgres_9:
 	docker run -p 5432:5432 --name postgres-9 -e POSTGRES_PASSWORD=$(POSTGRESQL_PASSWORD) -d postgres:9.5; \
@@ -27,17 +34,29 @@ stop_postgres_9:
 stop_postgres_10:
 	docker rm -f postgres-10
 
-start_mysql:
-	docker run -p 3307:3306 --name mysql -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -d mysql:5.7; \
-	until docker exec mysql mysqladmin ping --silent; do \
+start_mysql_57:
+	docker run -p 3307:3306 --name mysql-57 -e MYSQL_ROOT_PASSWORD=$(MYSQL_PASSWORD) -d mysql:5.7; \
+	until docker exec mysql-57 mysqladmin ping --silent; do \
 	    printf "."; sleep 1;                             \
 	done; \
 	sleep 5
 
-stop_mysql:
-	docker rm -f mysql
+start_mysql_80:
+	docker run -p 3307:3306 --name mysql-80 -e MYSQL_ROOT_PASSWORD=$(MYSQL_PASSWORD) -d mysql:8.0 \
+	    --default-authentication-plugin=mysql_native_password; \
+	until docker exec mysql-80 mysqladmin ping --silent; do \
+		printf "."; sleep 1;                             \
+	done; \
+	sleep 5
+
+stop_mysql_57:
+	docker rm -f mysql-57
+
+stop_mysql_80:
+	docker rm -f mysql-80
 
 stop_dbs:
-	docker rm -f mysql || true
+	docker rm -f mysql-57 || true
+	docker rm -f mysql-80 || true
 	docker rm -f postgres-9 || true
 	docker rm -f postgres-10 || true

--- a/ci/blackbox/config.json
+++ b/ci/blackbox/config.json
@@ -142,10 +142,10 @@
                     "plan_updateable": true,
                     "plans": [
                         {
-                            "description": "Micro plan",
+                            "description": "Micro plan - mysql 5.7",
                             "free": false,
-                            "id": "mysql-micro",
-                            "name": "micro",
+                            "id": "mysql-5.7-micro",
+                            "name": "micro-5.7",
                             "rds_properties": {
                                 "allocated_storage": 10,
                                 "db_instance_class": "db.t2.micro",
@@ -160,10 +160,10 @@
                             }
                         },
                         {
-                            "description": "Micro plan without final snapshot",
+                            "description": "Micro plan mysql 5.7 without final snapshot",
                             "free": false,
-                            "id": "mysql-micro-without-snapshot",
-                            "name": "micro-without-snapshot",
+                            "id": "mysql-5.7-micro-without-snapshot",
+                            "name": "micro-5.7-without-snapshot",
                             "rds_properties": {
                                 "allocated_storage": 10,
                                 "auto_minor_version_upgrade": true,
@@ -172,6 +172,45 @@
                                 "engine": "mysql",
                                 "engine_version": "5.7",
                                 "engine_family": "mysql5.7",
+                                "skip_final_snapshot": true,
+                                "copy_tags_to_snapshot":true,
+                                "vpc_security_group_ids": [
+                                    "POPULATED_BY_TEST_SUITE"
+                                ]
+                            }
+                        },
+
+                        {
+                            "description": "Micro plan - mysql 8.0",
+                            "free": false,
+                            "id": "mysql-8.0-micro",
+                            "name": "micro-8.0",
+                            "rds_properties": {
+                                "allocated_storage": 10,
+                                "db_instance_class": "db.t3.micro",
+                                "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
+                                "engine": "mysql",
+                                "engine_version": "8.0",
+                                "engine_family": "mysql8.0",
+                                "copy_tags_to_snapshot":true,
+                                "vpc_security_group_ids": [
+                                    "POPULATED_BY_TEST_SUITE"
+                                ]
+                            }
+                        },
+                        {
+                            "description": "Micro plan mysql 8.0 without final snapshot",
+                            "free": false,
+                            "id": "mysql-8.0-micro-without-snapshot",
+                            "name": "micro-without-snapshot",
+                            "rds_properties": {
+                                "allocated_storage": 10,
+                                "auto_minor_version_upgrade": true,
+                                "db_instance_class": "db.t3.micro",
+                                "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
+                                "engine": "mysql",
+                                "engine_version": "8.0",
+                                "engine_family": "mysql8.0",
                                 "skip_final_snapshot": true,
                                 "copy_tags_to_snapshot":true,
                                 "vpc_security_group_ids": [

--- a/ci/blackbox/rdsbroker_test.go
+++ b/ci/blackbox/rdsbroker_test.go
@@ -73,7 +73,7 @@ var _ = Describe("RDS Broker Daemon", func() {
 			Expect(service1.Description).To(Equal("AWS RDS MySQL service"))
 			Expect(service1.Bindable).To(BeTrue())
 			Expect(service1.PlanUpdatable).To(BeTrue())
-			Expect(service1.Plans).To(HaveLen(2))
+			Expect(service1.Plans).To(HaveLen(4))
 
 			Expect(service2.ID).To(Equal("postgres"))
 			Expect(service2.Name).To(Equal("postgres"))
@@ -220,8 +220,12 @@ var _ = Describe("RDS Broker Daemon", func() {
 			TestProvisionBindDeprovision("postgres", "postgres-micro-without-snapshot-10")
 		})
 
-		Describe("MySQL", func() {
-			TestProvisionBindDeprovision("mysql", "mysql-micro-without-snapshot")
+		Describe("MySQL 5.7", func() {
+			TestProvisionBindDeprovision("mysql", "mysql-5.7-micro-without-snapshot")
+		})
+
+		Describe("MySQL 8.0", func() {
+			TestProvisionBindDeprovision("mysql", "mysql-8.0-micro-without-snapshot")
 		})
 	})
 
@@ -381,8 +385,12 @@ var _ = Describe("RDS Broker Daemon", func() {
 			TestFinalSnapshot("postgres", "postgres-micro-10")
 		})
 
-		Describe("MySQL", func() {
-			TestFinalSnapshot("mysql", "mysql-micro")
+		Describe("MySQL 5.7", func() {
+			TestFinalSnapshot("mysql", "mysql-5.7-micro")
+		})
+
+		Describe("MySQL 8.0", func() {
+			TestFinalSnapshot("mysql", "mysql-8.0-micro")
 		})
 	})
 
@@ -500,8 +508,12 @@ var _ = Describe("RDS Broker Daemon", func() {
 			TestRestoreFromSnapshot("postgres", "postgres-micro-10")
 		})
 
-		PDescribe("MySQL", func() {
-			TestRestoreFromSnapshot("mysql", "mysql-micro")
+		PDescribe("MySQL 5.7", func() {
+			TestRestoreFromSnapshot("mysql", "mysql-5.7-micro")
+		})
+
+		PDescribe("MySQL 8.0", func() {
+			TestRestoreFromSnapshot("mysql", "mysql-8.0-micro")
 		})
 	})
 


### PR DESCRIPTION
What
---
We now support MySQL 5.7 and 8.0 via configuration in `paas-cf`. This PR adds unit and integration tests to validate that.

How to review
---
Code review
Check GitHub Actions and the integration tests in Concourse

Who can review
---
Anyone