### PR TITLE
[#169401847] Fix upgrading postgres and mysql

### DIFF
--- a/ci/blackbox/rdsbroker_test.go
+++ b/ci/blackbox/rdsbroker_test.go
@@ -326,7 +326,7 @@ var _ = Describe("RDS Broker Daemon", func() {
 			})
 		}
 
-		Describe("Postgres 9.5 to 10", func() {
+		XDescribe("Postgres 9.5 to 10 (disabled while postgres 9.5 upgrades are disabled)", func() {
 			TestUpdatePlan("postgres", "postgres-micro-without-snapshot", "postgres-micro-without-snapshot-10")
 		})
 

--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -285,9 +285,10 @@ func (b *RDSBroker) Update(
 		return brokerapi.UpdateServiceSpec{}, fmt.Errorf("Service '%s' not found", details.ServiceID)
 	}
 
-	if updateParameters.Reboot != nil && *updateParameters.Reboot {
-		if details.PlanID != details.PreviousValues.PlanID {
-			return brokerapi.UpdateServiceSpec{}, fmt.Errorf("Invalid to reboot and update plan in the same command")
+	if details.PlanID != details.PreviousValues.PlanID {
+		err := updateParameters.CheckForCompatibilityWithPlanChange()
+		if err != nil {
+			return brokerapi.UpdateServiceSpec{}, err
 		}
 	}
 

--- a/rdsbroker/broker_update_test.go
+++ b/rdsbroker/broker_update_test.go
@@ -1088,5 +1088,33 @@ var _ = Describe("RDS Broker", func() {
 				Expect(rdsInstance.RebootCallCount()).To(Equal(0))
 			})
 		})
+
+		Context("when the postgres version is being changed away from 9", func() {
+			BeforeEach(func() {
+				rdsProperties1.Engine = aws.String("postgres")
+				rdsProperties1.EngineVersion = aws.String("9.5")
+				rdsProperties2.Engine = aws.String("postgres")
+				rdsProperties2.EngineVersion = aws.String("10")
+			})
+
+			It("returns an error", func() {
+				_, err := rdsBroker.Update(ctx, instanceID, updateDetails, acceptsIncomplete)
+				Expect(err).To(MatchError("please contact support to upgrade from postgres 9"))
+			})
+		})
+
+		Context("when the postgres version is being changed from 9 to 9", func() {
+			BeforeEach(func() {
+				rdsProperties1.Engine = aws.String("postgres")
+				rdsProperties1.EngineVersion = aws.String("9.5")
+				rdsProperties2.Engine = aws.String("postgres")
+				rdsProperties2.EngineVersion = aws.String("9.6")
+			})
+
+			It("successfully upgrades the plan", func() {
+				_, err := rdsBroker.Update(ctx, instanceID, updateDetails, acceptsIncomplete)
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
 	})
 })

--- a/rdsbroker/broker_update_test.go
+++ b/rdsbroker/broker_update_test.go
@@ -866,6 +866,39 @@ var _ = Describe("RDS Broker", func() {
 			})
 		})
 
+		Context("when the plan is changing", func() {
+			BeforeEach(func() {
+				rdsProperties1.EngineVersion = stringPointer("1.2.3")
+				rdsProperties2.EngineVersion = stringPointer("4.5.6")
+				newParamGroupName = "mockedOutReturnValueOfSelectParameterGroupIndicatingUseOfEngineVersion4.5.6"
+
+				updateDetails = brokerapi.UpdateDetails{
+					ServiceID: "Service-1",
+					PlanID:    "Plan-2",
+					PreviousValues: brokerapi.PreviousValues{
+						PlanID:    "Plan-1",
+						ServiceID: "Service-1",
+						OrgID:     "organization-id",
+						SpaceID:   "space-id",
+					},
+				}
+			})
+
+			It("makes the proper calls", func() {
+				_, err := rdsBroker.Update(ctx, instanceID, updateDetails, acceptsIncomplete)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(paramGroupSelector.SelectParameterGroupCallCount()).To(Equal(1))
+				servicePlan, _ := paramGroupSelector.SelectParameterGroupArgsForCall(0)
+				Expect(servicePlan).To(Equal(plan2))
+
+				Expect(rdsInstance.ModifyCallCount()).To(Equal(1))
+				input := rdsInstance.ModifyArgsForCall(0)
+				Expect(aws.StringValue(input.EngineVersion)).To(Equal("4.5.6"))
+				Expect(aws.StringValue(input.DBParameterGroupName)).To(Equal(newParamGroupName))
+			})
+		})
+
 		Context("if an extension is in both enable_extensions and disable_enxtension", func() {
 			It("returns an error", func() {
 				updateDetails.RawParameters = json.RawMessage(`{"disable_extensions": ["postgres_super_extension"], "enable_extensions": ["postgres_super_extension"]}`)

--- a/rdsbroker/broker_update_test.go
+++ b/rdsbroker/broker_update_test.go
@@ -825,13 +825,13 @@ var _ = Describe("RDS Broker", func() {
 		})
 
 		It("accepts the enable_extensions parameter", func() {
-			updateDetails.RawParameters = json.RawMessage(`{"enable_extensions": []}`)
+			updateDetails.RawParameters = json.RawMessage(`{"enable_extensions": ["postgres_super_extension"]}`)
 			_, err := rdsBroker.Update(ctx, instanceID, updateDetails, acceptsIncomplete)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("accepts the disable_extensions parameter", func() {
-			updateDetails.RawParameters = json.RawMessage(`{"disable_extensions": []}`)
+			updateDetails.RawParameters = json.RawMessage(`{"disable_extensions": ["postgres_super_extension"]}`)
 			_, err := rdsBroker.Update(ctx, instanceID, updateDetails, acceptsIncomplete)
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/rdsbroker/parameters.go
+++ b/rdsbroker/parameters.go
@@ -44,3 +44,10 @@ func (up *UpdateParameters) Validate() error {
 	}
 	return nil
 }
+
+func (up *UpdateParameters) CheckForCompatibilityWithPlanChange() error {
+	if up.Reboot != nil && *up.Reboot {
+		return fmt.Errorf("Invalid to reboot and update plan in the same command")
+	}
+	return nil
+}

--- a/rdsbroker/parameters.go
+++ b/rdsbroker/parameters.go
@@ -49,5 +49,11 @@ func (up *UpdateParameters) CheckForCompatibilityWithPlanChange() error {
 	if up.Reboot != nil && *up.Reboot {
 		return fmt.Errorf("Invalid to reboot and update plan in the same command")
 	}
+	if len(up.EnableExtensions) > 0 {
+		return fmt.Errorf("Invalid to enable extensions and update plan in the same command")
+	}
+	if len(up.DisableExtensions) > 0 {
+		return fmt.Errorf("Invalid to disable extensions and update plan in the same command")
+	}
 	return nil
 }


### PR DESCRIPTION
What
-----

Prior to this PR we'd only update the parameter group if the extensions were changing. This broke updates when the plan was changing from an older engine version to a newer version - the parameter group needs to change here too.

To make things a bit simpler we've made it so the user can't change the plan and change the extensions at the same time.

With that simplification in place, we can just recalculate the parameter group for every update, which fixes the issue.

Once we'd fixed that issue we discovered another one preventing updates from postgres 9 to postgres 10 - the version of the postgis extension isn't compatible with this update, so it fails silently (the broker thinks it was successful, but it's actually still on the old version). This is a really bad user experience, so we've decided it's best to explicitly forbid updates from postgres 9 until we've played a follow up story to investigate fully (https://www.pivotaltracker.com/story/show/169477843).

How to review
-------------

* [x] Code review (done as pair)
* [x] Test manually in a dev environment (done in `towers`)
* [x] Wait for the integration tests to complete

Who can review
--------------

Miki and Richard are going to do it as a pair.
