### PR TITLE
Fix update request plan order

### DIFF
--- a/ci/helpers/brokerapi_helper.go
+++ b/ci/helpers/brokerapi_helper.go
@@ -149,7 +149,7 @@ func (b *BrokerAPIClient) DoUpdateRequest(instanceID, serviceID, planID string, 
 			},
 			"parameters": %s
 		}
-	`, serviceID, planID, newPlanID, paramJSON))
+	`, serviceID, newPlanID, planID, paramJSON))
 
 	return b.doRequest(
 		"PATCH",


### PR DESCRIPTION
Previously we were setting "plan_id" to the current plan id, and
"previous_plans.plan_id" to the new plan, which meant the upgrades
didn't happen.