### PR TITLE
[#172099629] Allow creation from snapshot before date

### DIFF
--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -237,6 +237,14 @@ func (b *RDSBroker) Provision(
 					prunedSnapshots = append(prunedSnapshots, snapshot)
 				}
 			}
+
+			b.logger.Info("pruned-snapshots", lager.Data{
+				"instanceIDLogKey":     instanceID,
+				"detailsLogKey":        details,
+				"allSnapshotsCount":    len(snapshots),
+				"prunedSnapshotsCount": len(prunedSnapshots),
+			})
+
 			snapshots = prunedSnapshots
 		}
 
@@ -245,6 +253,12 @@ func (b *RDSBroker) Provision(
 		}
 
 		snapshot := snapshots[0]
+
+		b.logger.Info("chose-snapshot", lager.Data{
+			"instanceIDLogKey":   instanceID,
+			"detailsLogKey":      details,
+			"snapshotIdentifier": snapshot.DBSnapshotIdentifier,
+		})
 
 		tags, err := b.dbInstance.GetResourceTags(aws.StringValue(snapshot.DBSnapshotArn))
 		if err != nil {

--- a/rdsbroker/parameters.go
+++ b/rdsbroker/parameters.go
@@ -3,14 +3,15 @@ package rdsbroker
 import "fmt"
 
 type ProvisionParameters struct {
-	BackupRetentionPeriod       int64    `json:"backup_retention_period"`
-	CharacterSetName            string   `json:"character_set_name"`
-	DBName                      string   `json:"dbname"`
-	PreferredBackupWindow       string   `json:"preferred_backup_window"`
-	PreferredMaintenanceWindow  string   `json:"preferred_maintenance_window"`
-	SkipFinalSnapshot           *bool    `json:"skip_final_snapshot"`
-	RestoreFromLatestSnapshotOf *string  `json:"restore_from_latest_snapshot_of"`
-	Extensions                  []string `json:"enable_extensions"`
+	BackupRetentionPeriod           int64    `json:"backup_retention_period"`
+	CharacterSetName                string   `json:"character_set_name"`
+	DBName                          string   `json:"dbname"`
+	PreferredBackupWindow           string   `json:"preferred_backup_window"`
+	PreferredMaintenanceWindow      string   `json:"preferred_maintenance_window"`
+	SkipFinalSnapshot               *bool    `json:"skip_final_snapshot"`
+	RestoreFromLatestSnapshotOf     *string  `json:"restore_from_latest_snapshot_of"`
+	RestoreFromLatestSnapshotBefore *string  `json:"restore_from_latest_snapshot_before"`
+	Extensions                      []string `json:"enable_extensions"`
 }
 
 type UpdateParameters struct {


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/172099629)

What
----

Currently when creating a new database from the snapshot of an existing one, only the last snapshot can be chosen

This PR adds a new flag, which can be used when creating from an existing snapshot:

```
# I ran this my dev env
cf create-service \
  postgres \
  tiny-unencrypted-11 \
  tlwr-test-snapshot \
  -c '{
    "restore_from_latest_snapshot_before": "2020-04-01 13:00:00", 
    "restore_from_latest_snapshot_of": "35a738c0-e53f-45f0-bf9f-f5a8f197b86d"
  }'
```

`restore_from_latest_snapshot_before` is optional, and only works with `restore_from_latest_snapshot_of`.

IMO this is a really nice UX (originally suggested by Andy Hunt)

How to review
---

- [ ] Code review
- [ ] Check `admin/noodle` where there are two databases created from snapshot one with `restore_from_latest_snapshot_before` and one without
- [ ] Check the RDS console in London for the two databases, and see that the tags are correctly set