### PR TITLE
[#172528011] Enable upgrading Postgres 9.5 database services

### DIFF
--- a/ci/blackbox/config.json
+++ b/ci/blackbox/config.json
@@ -34,8 +34,7 @@
                                     "POPULATED_BY_TEST_SUITE"
                                 ],
                                 "default_extensions": [
-                                    "uuid-ossp",
-                                    "postgis"
+                                    "uuid-ossp"
                                 ],
                                 "allowed_extensions": [
                                     "uuid-ossp",
@@ -63,8 +62,7 @@
                                     "POPULATED_BY_TEST_SUITE"
                                 ],
                                 "default_extensions": [
-                                    "uuid-ossp",
-                                    "postgis"
+                                    "uuid-ossp"
                                 ],
                                 "allowed_extensions": [
                                     "uuid-ossp",

--- a/ci/blackbox/rdsbroker_test.go
+++ b/ci/blackbox/rdsbroker_test.go
@@ -326,8 +326,93 @@ var _ = Describe("RDS Broker Daemon", func() {
 			})
 		}
 
-		XDescribe("Postgres 9.5 to 10 (disabled while postgres 9.5 upgrades are disabled)", func() {
-			TestUpdatePlan("postgres", "postgres-micro-without-snapshot", "postgres-micro-without-snapshot-10")
+		Describe("Postgres 9.5 to 10", func() {
+			Describe("when postgis extension is enabled", func() {
+				var (
+					instanceID string
+					serviceID  = "postgres"
+					startPlan  = "postgres-micro-without-snapshot"
+					endPlan    = "postgres-micro-without-snapshot-10"
+				)
+
+				BeforeEach(func() {
+					instanceID = uuid.NewV4().String()
+
+					brokerAPIClient.AcceptsIncomplete = true
+
+					params := `{
+						"enable_extensions": ["postgis"]
+					}`
+
+					code, operation, err := brokerAPIClient.ProvisionInstance(instanceID, serviceID, startPlan, params)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(code).To(Equal(202))
+					state := pollForOperationCompletion(brokerAPIClient, instanceID, serviceID, startPlan, operation)
+					Expect(state).To(Equal("succeeded"))
+				})
+
+				AfterEach(func() {
+					brokerAPIClient.AcceptsIncomplete = true
+					code, operation, err := brokerAPIClient.DeprovisionInstance(instanceID, serviceID, endPlan)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(code).To(Equal(202))
+					state := pollForOperationCompletion(brokerAPIClient, instanceID, serviceID, endPlan, operation)
+					Expect(state).To(Equal("gone"))
+				})
+
+				It("cannot be upgraded", func() {
+					code, operation, err := brokerAPIClient.UpdateInstance(instanceID, serviceID, startPlan, endPlan, `{}`)
+					Expect(err).ToNot(HaveOccurred(), "the 400 status code should not be an error")
+					Expect(code).To(Equal(400))
+					result := pollForOperationCompletion(brokerAPIClient, instanceID, serviceID, endPlan, operation)
+					Expect(result).To(
+						Equal("succeeded"),
+						"the status should be 'succeeded' because the state of the instance hasn't changed",
+					)
+				})
+			})
+
+			Describe("when postgis extension is not enabled", func() {
+				var (
+					instanceID string
+					serviceID  = "postgres"
+					startPlan  = "postgres-micro-without-snapshot"
+					endPlan    = "postgres-micro-without-snapshot-10"
+				)
+
+				BeforeEach(func() {
+					instanceID = uuid.NewV4().String()
+
+					brokerAPIClient.AcceptsIncomplete = true
+
+					params := `{
+						"enable_extensions": []
+					}`
+
+					code, operation, err := brokerAPIClient.ProvisionInstance(instanceID, serviceID, startPlan, params)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(code).To(Equal(202))
+					state := pollForOperationCompletion(brokerAPIClient, instanceID, serviceID, startPlan, operation)
+					Expect(state).To(Equal("succeeded"))
+				})
+
+				AfterEach(func() {
+					brokerAPIClient.AcceptsIncomplete = true
+					code, operation, err := brokerAPIClient.DeprovisionInstance(instanceID, serviceID, endPlan)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(code).To(Equal(202))
+					state := pollForOperationCompletion(brokerAPIClient, instanceID, serviceID, endPlan, operation)
+					Expect(state).To(Equal("gone"))
+				})
+
+				It("can be upgraded", func() {
+					code, operation, err := brokerAPIClient.UpdateInstance(instanceID, serviceID, startPlan, endPlan, `{}`)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(code).To(Equal(202))
+					result := pollForOperationCompletion(brokerAPIClient, instanceID, serviceID, endPlan, operation)
+					Expect(result).To(Equal("succeeded"))
+				})
+			})
 		})
 
 		Describe("Postgres 10 to 11", func() {
@@ -804,7 +889,6 @@ func postgresExtensionsTest(databaseURI string) error {
 		}
 		Expect(rows.Err()).ToNot(HaveOccurred())
 		Expect(extensions).To(ContainElement("uuid-ossp"))
-		Expect(extensions).To(ContainElement("postgis"))
 	case "mysql":
 		// There are no MySQL-specific tests
 	default:


### PR DESCRIPTION
What
---
Allow Postgres 9.5 service instances to be upgraded to a newer version when the `postgis` extension is not enabled.

Upgrading with it enabled is broken.

How to review
---
[See the `paas-cf` PR](https://github.com/alphagov/paas-cf/pull/2310)

Who can review
---
Anyone