### PR TITLE
[support ] Enable instances in `storage-optimization` state to allow binding

### DIFF
--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -44,6 +44,7 @@ var (
 
 var rdsStatus2State = map[string]brokerapi.LastOperationState{
 	"available":                           brokerapi.Succeeded,
+	"storage-optimization":                brokerapi.Succeeded,
 	"backing-up":                          brokerapi.InProgress,
 	"creating":                            brokerapi.InProgress,
 	"deleting":                            brokerapi.InProgress,
@@ -58,7 +59,6 @@ var rdsStatus2State = map[string]brokerapi.LastOperationState{
 	"stopping":                            brokerapi.InProgress,
 	"stopped":                             brokerapi.InProgress,
 	"storage-full":                        brokerapi.InProgress,
-	"storage-optimization":                brokerapi.InProgress,
 	"failed":                              brokerapi.Failed,
 	"incompatible-credentials":            brokerapi.Failed,
 	"incompatible-network":                brokerapi.Failed,

--- a/rdsbroker/broker_test.go
+++ b/rdsbroker/broker_test.go
@@ -2394,6 +2394,7 @@ var _ = Describe("RDS Broker", func() {
 
 		successStatuses := []string{
 			"available",
+			"storage-optimization",
 		}
 		for _, instanceStatus := range successStatuses {
 			Context("when instance status is "+instanceStatus, checkLastOperationResponse(instanceStatus, brokerapi.Succeeded))
@@ -2413,7 +2414,6 @@ var _ = Describe("RDS Broker", func() {
 			"stopping",
 			"stopped",
 			"storage-full",
-			"storage-optimization",
 			"upgrading",
 		}
 		for _, instanceStatus := range inProgressStatuses {


### PR DESCRIPTION
## What

In the previous broker behaviour instances that were in
`storage-optimization` remained in `InProgress` which prevented
applications from being bound to the instance.

However according to AWS support

```
While the instance is in the 'storage-optimization' state,
- The instance is fully operational.
- You cannot make any 'storage' related modifications but other modifications are allowed.
```

So we should enable tenants to bind applications whilst this background
operation is happening.

## How to review

Code review
Check the tests pass

## Who can review

Anyone