### PR TITLE
Adding Read-Only user creation at binding.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 POSTGRESQL_PASSWORD=abc123
 MYSQL_PASSWORD=toor
+POSTGRESQL_MASTER_USERNAME=UpCHB6aPJ9VVRBsn
+POSTGRESQL_MASTER_PASSWORD=secret
+POSTGRESQL_RDSADMIN_USERNAME=rdsadmin
+POSTGRESQL_RDSADMIN_PASSWORD=secret
 
 .PHONY: integration
 integration:
@@ -29,17 +33,29 @@ run_postgres_sql_tests:
 .PHONY: start_postgres_9
 start_postgres_9:
 	docker run -p 5432:5432 --name postgres-9 -e POSTGRES_PASSWORD=$(POSTGRESQL_PASSWORD) -d postgres:9.5; \
-	sleep 5
+	sleep 10; \
+	PGPASSWORD=$(POSTGRESQL_PASSWORD) psql -h localhost -p 5432 -U postgres -c "CREATE DATABASE pgdb;"; \
+	PGPASSWORD=$(POSTGRESQL_PASSWORD) psql -h localhost -p 5432 -U postgres -c "CREATE DATABASE rdsadmin;"; \
+	PGPASSWORD=$(POSTGRESQL_PASSWORD) psql -h localhost -p 5432 -U postgres pgdb -f  globals.sql; \
+	PGPASSWORD=$(POSTGRESQL_PASSWORD) psql -h localhost -p 5432 -U postgres pgdb -f db.sql;
 
 .PHONY: start_postgres_10
 start_postgres_10:
 	docker run -p 5432:5432 --name postgres-10 -e POSTGRES_PASSWORD=$(POSTGRESQL_PASSWORD) -d postgres:10.5; \
-	sleep 5
+	sleep 10; \
+	PGPASSWORD=$(POSTGRESQL_PASSWORD) psql -h localhost -p 5432 -U postgres -c "CREATE DATABASE pgdb;"; \
+	PGPASSWORD=$(POSTGRESQL_PASSWORD) psql -h localhost -p 5432 -U postgres -c "CREATE DATABASE rdsadmin;"; \
+	PGPASSWORD=$(POSTGRESQL_PASSWORD) psql -h localhost -p 5432 -U postgres pgdb -f globals.sql; \
+	PGPASSWORD=$(POSTGRESQL_PASSWORD) psql -h localhost -p 5432 -U postgres pgdb -f db.sql; 
 
 .PHONY: start_postgres_11
 start_postgres_11:
 	docker run -p 5432:5432 --name postgres-11 -e POSTGRES_PASSWORD=$(POSTGRESQL_PASSWORD) -d postgres:11.5; \
-	sleep 5
+	sleep 10; \
+	PGPASSWORD=$(POSTGRESQL_PASSWORD) psql -h localhost -p 5432 -U postgres -c "CREATE DATABASE pgdb;"; \
+	PGPASSWORD=$(POSTGRESQL_PASSWORD) psql -h localhost -p 5432 -U postgres -c "CREATE DATABASE rdsadmin;"; \
+	PGPASSWORD=$(POSTGRESQL_PASSWORD) psql -h localhost -p 5432 -U postgres pgdb -f globals.sql; \
+	PGPASSWORD=$(POSTGRESQL_PASSWORD) psql -h localhost -p 5432 -U postgres pgdb -f db.sql;
 
 .PHONY: stop_postgres_9
 stop_postgres_9:
@@ -59,7 +75,7 @@ start_mysql_57:
 	until docker exec mysql-57 mysqladmin ping --silent; do \
 	    printf "."; sleep 1;                             \
 	done; \
-	sleep 5
+	sleep 10
 
 .PHONY: start_mysql_80
 start_mysql_80:
@@ -68,7 +84,7 @@ start_mysql_80:
 	until docker exec mysql-80 mysqladmin ping --silent; do \
 		printf "."; sleep 1;                             \
 	done; \
-	sleep 5
+	sleep 10
 
 .PHONY: stop_mysql_57
 stop_mysql_57:

--- a/db.sql
+++ b/db.sql
@@ -1,0 +1,125 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 10.11
+-- Dumped by pg_dump version 10.13 (Ubuntu 10.13-1.pgdg16.04+1)
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: 
+--
+
+CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
+
+
+--
+-- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: 
+--
+
+COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
+
+
+--
+-- Name: citext; Type: EXTENSION; Schema: -; Owner: 
+--
+
+CREATE EXTENSION IF NOT EXISTS citext WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION citext; Type: COMMENT; Schema: -; Owner: 
+--
+
+COMMENT ON EXTENSION citext IS 'data type for case-insensitive character strings';
+
+
+--
+-- Name: postgis; Type: EXTENSION; Schema: -; Owner: 
+--
+
+-- CREATE EXTENSION IF NOT EXISTS postgis WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION postgis; Type: COMMENT; Schema: -; Owner: 
+--
+
+-- COMMENT ON EXTENSION postgis IS 'PostGIS geometry, geography, and raster spatial types and functions';
+
+
+--
+-- Name: uuid-ossp; Type: EXTENSION; Schema: -; Owner: 
+--
+
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp" WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION "uuid-ossp"; Type: COMMENT; Schema: -; Owner: 
+--
+
+COMMENT ON EXTENSION "uuid-ossp" IS 'generate universally unique identifiers (UUIDs)';
+
+
+--
+-- Data for Name: spatial_ref_sys; Type: TABLE DATA; Schema: public; Owner: rdsadmin
+--
+
+-- COPY public.spatial_ref_sys (srid, auth_name, auth_srid, srtext, proj4text) FROM stdin;
+-- \.
+
+
+--
+-- Name: SCHEMA public; Type: ACL; Schema: -; Owner: UpCHB6aPJ9VVRBsn
+--
+
+REVOKE ALL ON SCHEMA public FROM rdsadmin;
+REVOKE ALL ON SCHEMA public FROM PUBLIC;
+GRANT ALL ON SCHEMA public TO "UpCHB6aPJ9VVRBsn";
+GRANT ALL ON SCHEMA public TO PUBLIC;
+
+
+--
+-- PostgreSQL database dump complete
+--
+
+--
+-- SET Passowrds for uploaded users
+--
+
+ALTER USER "UpCHB6aPJ9VVRBsn" WITH PASSWORD 'secret';
+ALTER USER "rdsadmin" WITH PASSWORD 'secret';
+
+--
+-- CHANING the tablespace owner
+--
+ALTER TABLESPACE pg_default OWNER TO rdsadmin;
+ALTER TABLESPACE pg_global OWNER TO rdsadmin;
+
+--
+-- CHANGING the SCHEMA OWNER
+--
+--ALTER SCHEMA public OWNER TO "UpCHB6aPJ9VVRBsn";
+
+ALTER SCHEMA public OWNER TO rdsadmin;
+
+--
+-- CHANGING the DBs owner
+--
+
+ALTER DATABASE pgdb OWNER TO "UpCHB6aPJ9VVRBsn";
+ALTER DATABASE rdsadmin OWNER TO rdsadmin;
+ALTER DATABASE postgres OWNER TO "UpCHB6aPJ9VVRBsn";
+ALTER DATABASE template1 OWNER TO "UpCHB6aPJ9VVRBsn";
+ALTER DATABASE template0 OWNER TO rdsadmin;

--- a/globals.sql
+++ b/globals.sql
@@ -1,0 +1,70 @@
+--
+-- PostgreSQL database cluster dump
+--
+
+SET default_transaction_read_only = off;
+
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+
+--
+-- Roles
+--
+
+CREATE ROLE "UpCHB6aPJ9VVRBsn";
+ALTER ROLE "UpCHB6aPJ9VVRBsn" WITH NOSUPERUSER INHERIT CREATEROLE CREATEDB LOGIN NOREPLICATION NOBYPASSRLS VALID UNTIL 'infinity';
+CREATE ROLE rds_ad;
+ALTER ROLE rds_ad WITH NOSUPERUSER INHERIT NOCREATEROLE NOCREATEDB NOLOGIN NOREPLICATION NOBYPASSRLS;
+CREATE ROLE rds_iam;
+ALTER ROLE rds_iam WITH NOSUPERUSER INHERIT NOCREATEROLE NOCREATEDB NOLOGIN NOREPLICATION NOBYPASSRLS;
+CREATE ROLE rds_password;
+ALTER ROLE rds_password WITH NOSUPERUSER INHERIT NOCREATEROLE NOCREATEDB NOLOGIN NOREPLICATION NOBYPASSRLS;
+CREATE ROLE rds_replication;
+ALTER ROLE rds_replication WITH NOSUPERUSER INHERIT NOCREATEROLE NOCREATEDB NOLOGIN NOREPLICATION NOBYPASSRLS;
+CREATE ROLE rds_superuser;
+ALTER ROLE rds_superuser WITH NOSUPERUSER INHERIT NOCREATEROLE NOCREATEDB NOLOGIN NOREPLICATION NOBYPASSRLS;
+CREATE ROLE rdsadmin;
+ALTER ROLE rdsadmin WITH SUPERUSER INHERIT CREATEROLE CREATEDB LOGIN REPLICATION BYPASSRLS VALID UNTIL 'infinity';
+CREATE ROLE rdsrepladmin;
+ALTER ROLE rdsrepladmin WITH NOSUPERUSER NOINHERIT NOCREATEROLE NOCREATEDB NOLOGIN REPLICATION NOBYPASSRLS;
+ALTER ROLE rdsadmin SET "TimeZone" TO 'utc';
+ALTER ROLE rdsadmin SET log_statement TO 'all';
+ALTER ROLE rdsadmin SET log_min_error_statement TO 'debug5';
+ALTER ROLE rdsadmin SET log_min_messages TO 'panic';
+ALTER ROLE rdsadmin SET exit_on_error TO '0';
+ALTER ROLE rdsadmin SET statement_timeout TO '0';
+ALTER ROLE rdsadmin SET role TO 'rdsadmin';
+ALTER ROLE rdsadmin SET "auto_explain.log_min_duration" TO '-1';
+ALTER ROLE rdsadmin SET temp_file_limit TO '-1';
+ALTER ROLE rdsadmin SET search_path TO 'pg_catalog', 'public';
+ALTER ROLE rdsadmin SET "pg_hint_plan.enable_hint" TO 'off';
+ALTER ROLE rdsadmin SET default_transaction_read_only TO 'off';
+
+
+--
+-- Role memberships
+--
+
+GRANT pg_monitor TO rds_superuser WITH ADMIN OPTION GRANTED BY rdsadmin;
+GRANT pg_signal_backend TO rds_superuser WITH ADMIN OPTION GRANTED BY rdsadmin;
+GRANT rds_password TO rds_superuser WITH ADMIN OPTION GRANTED BY rdsadmin;
+GRANT rds_replication TO rds_superuser WITH ADMIN OPTION GRANTED BY rdsadmin;
+GRANT rds_superuser TO "UpCHB6aPJ9VVRBsn" GRANTED BY rdsadmin;
+
+
+
+
+--
+-- Per-Database Role Settings
+--
+
+ALTER ROLE rdsadmin IN DATABASE rdsadmin SET log_min_messages TO 'panic';
+
+
+--
+-- PostgreSQL database cluster dump complete
+--
+
+
+
+

--- a/rdsbroker/parameters.go
+++ b/rdsbroker/parameters.go
@@ -29,6 +29,7 @@ type UpdateParameters struct {
 type BindParameters struct {
 	// This is currently empty, but preserved to make it easier to add
 	// bind-time parameters in future.
+	ReadOnly *bool `json:"read_only"`
 }
 
 func (pp *ProvisionParameters) Validate() error {

--- a/sqlengine/fakes/fake_sql_engine.go
+++ b/sqlengine/fakes/fake_sql_engine.go
@@ -17,9 +17,11 @@ type FakeSQLEngine struct {
 
 	CloseCalled bool
 
-	CreateUserCalled    bool
-	CreateUserBindingID string
-	CreateUserDBName    string
+	CreateUserCalled         bool
+	CreateUserBindingID      string
+	CreateUserDBName         string
+	CreateUserMasterUsername string
+	CreateUserReadOnly       *bool
 	// returns
 	CreateUserUsername string
 	CreateUserPassword string
@@ -58,10 +60,12 @@ func (f *FakeSQLEngine) Close() {
 	f.CloseCalled = true
 }
 
-func (f *FakeSQLEngine) CreateUser(bindingID, dbname string) (username, password string, err error) {
+func (f *FakeSQLEngine) CreateUser(bindingID, dbname, masterUsername string, readOnly *bool) (username, password string, err error) {
 	f.CreateUserCalled = true
 	f.CreateUserBindingID = bindingID
 	f.CreateUserDBName = dbname
+	f.CreateUserMasterUsername = masterUsername
+	f.CreateUserReadOnly = readOnly
 
 	return f.CreateUserUsername, f.CreateUserPassword, f.CreateUserError
 }

--- a/sqlengine/mysql_engine.go
+++ b/sqlengine/mysql_engine.go
@@ -62,7 +62,7 @@ func (d *MySQLEngine) Close() {
 	}
 }
 
-func (d *MySQLEngine) CreateUser(bindingID, dbname string) (username, password string, err error) {
+func (d *MySQLEngine) CreateUser(bindingID, dbname, masterUsername string, readOnly *bool) (username, password string, err error) {
 	username = d.UsernameGenerator(bindingID)
 	password = generatePassword()
 	options := []string{

--- a/sqlengine/mysql_engine_test.go
+++ b/sqlengine/mysql_engine_test.go
@@ -43,6 +43,8 @@ var _ = Describe("MySQLEngine", func() {
 		password string
 
 		template1ConnectionString string
+
+		readOnlyUser = false
 	)
 
 	BeforeEach(func() {
@@ -107,7 +109,7 @@ var _ = Describe("MySQLEngine", func() {
 		})
 
 		It("CreateUser() should successfully complete it's destiny", func() {
-			createdUser, createdPassword, err := mysqlEngine.CreateUser(bindingID, dbname)
+			createdUser, createdPassword, err := mysqlEngine.CreateUser(bindingID, dbname, username, &readOnlyUser)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(createdUser).NotTo(BeEmpty())
 			Expect(createdPassword).NotTo(BeEmpty())
@@ -126,7 +128,7 @@ var _ = Describe("MySQLEngine", func() {
 		It("DropUser() should drop the username generated the old way successfully", func() {
 			mysqlEngine.UsernameGenerator = generateUsernameOld
 
-			_, _, err := mysqlEngine.CreateUser(bindingID, dbname)
+			_, _, err := mysqlEngine.CreateUser(bindingID, dbname, username, &readOnlyUser)
 			Expect(err).ToNot(HaveOccurred())
 
 			mysqlEngine.UsernameGenerator = generateUsername

--- a/sqlengine/sql_engine.go
+++ b/sqlengine/sql_engine.go
@@ -15,7 +15,7 @@ const (
 type SQLEngine interface {
 	Open(address string, port int64, dbname string, username string, password string) error
 	Close()
-	CreateUser(bindingID, dbname string) (string, string, error)
+	CreateUser(bindingID, dbname, masterUsername string, readOnly *bool) (string, string, error)
 	DropUser(bindingID string) error
 	ResetState() error
 	URI(address string, port int64, dbname string, username string, password string) string


### PR DESCRIPTION
What
-------
Our tenants asked for an ability to connect to the database instances that are managed by PaaS with a READ-ONLY user, to avoid changing the database by mistake, while troubleshooting for example.

We have changed the way we grant privileges to the created user during the binding of the database to the application. We are using custom parameter `read_only` (true|false) during `cf bind-service` command.

How to review
-------------------
- Code review
- Deploy CF to your DEV environment from latest master
- Make sure that internal apps with database are deployed and working - e.g. auditor, accounts, billing.
- Deploy CF to your DEV environment from the branch in (alphagov/paas-cf/pull/2417).
- Make sure pipeline is green
- bind to the existing db (auditor-db, accounts-db or billing-db) with another app (e.g.: static application will do).
  - deploy static-app
  - `cf bind-service static-app auditor-db -c '{"read_only": true}'`
- connect to the `auditor-db`  from bosh rds-broker instance with the read_only credentials (e.g.: you can get the creds via `cf env static-app`).
- connect to the `auditor-db` via conduit plugin - `cf conduit auditor-db -- psql`
  - create and populate a table in conduit session - check that you can access and read data from that table in the read-only session.
  -  create a new schema, table in that schema and populate the table in conduit session - check that you can access and read data from that schema/table in the read-only session.
  - create function in conduit session - check that you can user that function in the read-only session.

Who can review
---------------------
not @barsutka 