### PR TITLE
[#173938510] Keep patch level when modifying similar engine versions

### DIFF
--- a/awsrds/rds_db_instance_test.go
+++ b/awsrds/rds_db_instance_test.go
@@ -686,6 +686,39 @@ var _ = Describe("RDS DB Instance", func() {
 			Expect(aws.StringValue(updatedDBInstance.DBInstanceStatus)).To(Equal("updated"))
 		})
 
+		It("keeps EngineVersion if new major and minor version match", func() {
+			modifyDBInstanceInput := &rds.ModifyDBInstanceInput{
+				DBInstanceIdentifier: aws.String(dbInstanceIdentifier),
+				EngineVersion:        aws.String("1.2.1"),
+			}
+
+			_, err := rdsDBInstance.Modify(modifyDBInstanceInput)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(receivedModifyDBInstanceInput.EngineVersion).To(Equal(aws.String("1.2.3")))
+		})
+
+		It("sets EngineVersion if new major version differs", func() {
+			modifyDBInstanceInput := &rds.ModifyDBInstanceInput{
+				DBInstanceIdentifier: aws.String(dbInstanceIdentifier),
+				EngineVersion:        aws.String("2.2.1"),
+			}
+
+			_, err := rdsDBInstance.Modify(modifyDBInstanceInput)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(receivedModifyDBInstanceInput.EngineVersion).To(Equal(aws.String("2.2.1")))
+		})
+
+		It("sets EngineVersion if new minor version differs", func() {
+			modifyDBInstanceInput := &rds.ModifyDBInstanceInput{
+				DBInstanceIdentifier: aws.String(dbInstanceIdentifier),
+				EngineVersion:        aws.String("1.3.1"),
+			}
+
+			_, err := rdsDBInstance.Modify(modifyDBInstanceInput)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(receivedModifyDBInstanceInput.EngineVersion).To(Equal(aws.String("1.3.1")))
+		})
+
 		It("sets AllowMajorVersionUpgrade to true by default", func() {
 			modifyDBInstanceInput := &rds.ModifyDBInstanceInput{
 				DBInstanceIdentifier:     aws.String(dbInstanceIdentifier),


### PR DESCRIPTION
What
----
We are not prescribing the patch level in the RDS service catalog plans in order to make use of the auto minor version upgrade feature.

This means that AWS chooses the patch level when creating or modifying an instance. If the patch-level chosen for the modification is for some reason lower than the patch-level of the current instance `cf update-service` will fail.

This change preserves the patch-level of the current instance when updating the plan, if the major and minor versions are the same. It also adds tests.

How to review
-------------
- Code review
- Tests pass
- Test behaviour in dev environment,  e.g.:
  - `cf create-service mysql small-5.7 test-db-update`
  - Trigger auto minor version upgrade (expected 5.7.22 -> 5.7.26)
  - `cf update-service test-db-update -p medium-ha-5.7`

Who can review
--------------
Not @schmie


