### PR TITLE
Postgres read only bindings via event triggers

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -47,3 +47,23 @@ jobs:
       - name: Run tests
         run: |
           make unit
+
+      - name: Run postgres 9 tests
+        run: |
+          make start_postgres_9 run_postgres_sql_tests stop_postgres_9
+
+      - name: Run postgres 10 tests
+        run: |
+          make start_postgres_10 run_postgres_sql_tests stop_postgres_10
+
+      - name: Run postgres 11 tests
+        run: |
+          make start_postgres_11 run_postgres_sql_tests stop_postgres_11
+
+      - name: Run mysql 8.0
+        run: |
+          make start_mysql_80 run_mysql_sql_tests stop_mysql_80
+
+      - name: Run mysql 5.7
+        run: |
+          make start_mysql_57 run_mysql_sql_tests stop_mysql_57

--- a/ci/helpers/brokerapi_helper.go
+++ b/ci/helpers/brokerapi_helper.go
@@ -243,8 +243,6 @@ func (b *BrokerAPIClient) DoLastOperationRequest(instanceID, serviceID, planID, 
 		uriParam{key: "plan_id", value: planID},
 		uriParam{key: "operation", value: operation},
 	)
-
-	return b.doRequest("GET", path, nil)
 }
 
 func (b *BrokerAPIClient) GetLastOperationState(instanceID, serviceID, planID, operation string) (string, error) {
@@ -272,8 +270,6 @@ func (b *BrokerAPIClient) GetLastOperationState(instanceID, serviceID, planID, o
 	default:
 		return "", fmt.Errorf("Unknown code %d: %s", resp.StatusCode, string(body))
 	}
-
-	return "", nil
 }
 
 func (b *BrokerAPIClient) DoBindRequest(instanceID, serviceID, planID, appGUID, bindingID string) (*http.Response, error) {

--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -598,7 +598,7 @@ func (b *RDSBroker) Bind(
 	}
 	defer sqlEngine.Close()
 
-	dbUsername, dbPassword, err := sqlEngine.CreateUser(bindingID, dbName)
+	dbUsername, dbPassword, err := sqlEngine.CreateUser(bindingID, dbName, false)
 	if err != nil {
 		return bindingResponse, err
 	}

--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -579,6 +579,10 @@ func (b *RDSBroker) Bind(
 		return bindingResponse, err
 	}
 
+	if aws.StringValue(dbInstance.Engine) != "postgres" && bindParameters.ReadOnly {
+		return bindingResponse, fmt.Errorf("Read only bindings are only supported for postgres")
+	}
+
 	dbAddress := awsrds.GetDBAddress(dbInstance.Endpoint)
 	dbPort := awsrds.GetDBPort(dbInstance.Endpoint)
 	masterUsername := aws.StringValue(dbInstance.MasterUsername)
@@ -598,7 +602,7 @@ func (b *RDSBroker) Bind(
 	}
 	defer sqlEngine.Close()
 
-	dbUsername, dbPassword, err := sqlEngine.CreateUser(bindingID, dbName, false)
+	dbUsername, dbPassword, err := sqlEngine.CreateUser(bindingID, dbName, bindParameters.ReadOnly)
 	if err != nil {
 		return bindingResponse, err
 	}

--- a/rdsbroker/parameters.go
+++ b/rdsbroker/parameters.go
@@ -27,8 +27,7 @@ type UpdateParameters struct {
 }
 
 type BindParameters struct {
-	// This is currently empty, but preserved to make it easier to add
-	// bind-time parameters in future.
+	ReadOnly bool `json:"read_only"`
 }
 
 func (pp *ProvisionParameters) Validate() error {

--- a/sqlengine/fakes/fake_sql_engine.go
+++ b/sqlengine/fakes/fake_sql_engine.go
@@ -20,6 +20,7 @@ type FakeSQLEngine struct {
 	CreateUserCalled    bool
 	CreateUserBindingID string
 	CreateUserDBName    string
+	CreateUserReadOnly  bool
 	// returns
 	CreateUserUsername string
 	CreateUserPassword string
@@ -58,10 +59,11 @@ func (f *FakeSQLEngine) Close() {
 	f.CloseCalled = true
 }
 
-func (f *FakeSQLEngine) CreateUser(bindingID, dbname string) (username, password string, err error) {
+func (f *FakeSQLEngine) CreateUser(bindingID, dbname string, readOnly bool) (username, password string, err error) {
 	f.CreateUserCalled = true
 	f.CreateUserBindingID = bindingID
 	f.CreateUserDBName = dbname
+	f.CreateUserReadOnly = readOnly
 
 	return f.CreateUserUsername, f.CreateUserPassword, f.CreateUserError
 }

--- a/sqlengine/mysql_engine.go
+++ b/sqlengine/mysql_engine.go
@@ -62,7 +62,7 @@ func (d *MySQLEngine) Close() {
 	}
 }
 
-func (d *MySQLEngine) CreateUser(bindingID, dbname string) (username, password string, err error) {
+func (d *MySQLEngine) CreateUser(bindingID, dbname string, readOnly bool) (username, password string, err error) {
 	username = d.UsernameGenerator(bindingID)
 	password = generatePassword()
 	options := []string{

--- a/sqlengine/mysql_engine_test.go
+++ b/sqlengine/mysql_engine_test.go
@@ -107,7 +107,7 @@ var _ = Describe("MySQLEngine", func() {
 		})
 
 		It("CreateUser() should successfully complete it's destiny", func() {
-			createdUser, createdPassword, err := mysqlEngine.CreateUser(bindingID, dbname)
+			createdUser, createdPassword, err := mysqlEngine.CreateUser(bindingID, dbname, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(createdUser).NotTo(BeEmpty())
 			Expect(createdPassword).NotTo(BeEmpty())
@@ -126,7 +126,7 @@ var _ = Describe("MySQLEngine", func() {
 		It("DropUser() should drop the username generated the old way successfully", func() {
 			mysqlEngine.UsernameGenerator = generateUsernameOld
 
-			_, _, err := mysqlEngine.CreateUser(bindingID, dbname)
+			_, _, err := mysqlEngine.CreateUser(bindingID, dbname, false)
 			Expect(err).ToNot(HaveOccurred())
 
 			mysqlEngine.UsernameGenerator = generateUsername

--- a/sqlengine/postgres_engine.go
+++ b/sqlengine/postgres_engine.go
@@ -394,6 +394,7 @@ const ensurePermissionsTriggersPattern = `
 		FOR r in (select schema_name from information_schema.schemata) LOOP
 			BEGIN
 				EXECUTE format('GRANT SELECT ON ALL TABLES IN SCHEMA %s TO "{{.dbname}}_reader"', r.schema_name);
+				EXECUTE format('GRANT SELECT ON ALL SEQUENCES IN SCHEMA %s TO "{{.dbname}}_reader"', r.schema_name);
 				EXECUTE format('GRANT USAGE ON SCHEMA %s TO "{{.dbname}}_reader"', r.schema_name);
 
 				RAISE NOTICE 'GRANTED READ ONLY IN SCHEMA %s', r.schema_name;
@@ -451,7 +452,7 @@ func (d *PostgresEngine) ensurePermissionsTriggers(tx *sql.Tx, dbname string) er
 		`drop event trigger if exists reassign_owned;`,
 		`create event trigger reassign_owned on ddl_command_end execute procedure reassign_owned();`,
 		`drop event trigger if exists make_readable;`,
-		`create event trigger make_readable on ddl_command_end when tag in ('CREATE TABLE', 'CREATE TABLE AS', 'CREATE SCHEMA') execute procedure make_readable();`,
+		`create event trigger make_readable on ddl_command_end when tag in ('CREATE TABLE', 'CREATE TABLE AS', 'CREATE SCHEMA', 'CREATE VIEW', 'CREATE SEQUENCE') execute procedure make_readable();`,
 		`drop event trigger if exists forbid_ddl_reader;`,
 		`create event trigger forbid_ddl_reader on ddl_command_start execute procedure forbid_ddl_reader();`,
 	}

--- a/sqlengine/postgres_engine_test.go
+++ b/sqlengine/postgres_engine_test.go
@@ -302,6 +302,9 @@ var _ = Describe("PostgresEngine", func() {
 				_, err = db.Exec("INSERT INTO tbl (col) VALUES ('public-other')")
 				Expect(err).ToNot(HaveOccurred())
 
+				_, err = db.Exec("CREATE SEQUENCE seq START 99") // red balloons
+				Expect(err).ToNot(HaveOccurred())
+
 				_, err = db.Exec("CREATE SCHEMA private")
 				Expect(err).ToNot(HaveOccurred())
 
@@ -309,6 +312,9 @@ var _ = Describe("PostgresEngine", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				_, err = db.Exec("INSERT INTO private.tbl (col) VALUES ('private-other')")
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = db.Exec("CREATE SEQUENCE private.seq START 99") // red balloons
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Creating a read-only user")
@@ -326,7 +332,13 @@ var _ = Describe("PostgresEngine", func() {
 				_, err = db.Exec("DROP TABLE tbl")
 				Expect(err).ToNot(HaveOccurred())
 
+				_, err = db.Exec("DROP SEQUENCE seq")
+				Expect(err).ToNot(HaveOccurred())
+
 				_, err = db.Exec("DROP TABLE private.tbl")
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = db.Exec("DROP SEQUENCE private.seq")
 				Expect(err).ToNot(HaveOccurred())
 
 				_, err = db.Exec("DROP SCHEMA private CASCADE")
@@ -346,6 +358,14 @@ var _ = Describe("PostgresEngine", func() {
 
 				_, err = db.Exec("SELECT * FROM private.tbl")
 				Expect(err).NotTo(HaveOccurred(), "Read only users can SELECT")
+
+				By("checking SELECT from sequences work")
+
+				_, err = db.Exec("SELECT last_value FROM private.seq")
+				Expect(err).NotTo(HaveOccurred(), "Read only users can SELECT from a sequence")
+
+				_, err = db.Exec("SELECT last_value FROM seq")
+				Expect(err).NotTo(HaveOccurred(), "Read only users can SELECT from a sequence in the public schema")
 
 				By("checking INSERT is denied")
 

--- a/sqlengine/postgres_engine_test.go
+++ b/sqlengine/postgres_engine_test.go
@@ -210,7 +210,7 @@ var _ = Describe("PostgresEngine", func() {
 					Expect(err).ToNot(HaveOccurred())
 					defer postgresEngine.Close()
 
-					_, _, err = postgresEngine.CreateUser(bindingID, dbname)
+					_, _, err = postgresEngine.CreateUser(bindingID, dbname, false)
 					Expect(err).ToNot(HaveOccurred())
 
 					err = postgresEngine.DropUser(bindingID)
@@ -236,7 +236,7 @@ var _ = Describe("PostgresEngine", func() {
 			err := postgresEngine.Open(address, port, dbname, masterUsername, masterPassword)
 			Expect(err).ToNot(HaveOccurred())
 
-			createdUser, createdPassword, err = postgresEngine.CreateUser(bindingID, dbname)
+			createdUser, createdPassword, err = postgresEngine.CreateUser(bindingID, dbname, false)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -293,7 +293,7 @@ var _ = Describe("PostgresEngine", func() {
 			BeforeEach(func() {
 				var err error
 				otherBindingID = "other-binding-id" + randomTestSuffix
-				otherCreatedUser, otherCreatedPassword, err = postgresEngine.CreateUser(otherBindingID, dbname)
+				otherCreatedUser, otherCreatedPassword, err = postgresEngine.CreateUser(otherBindingID, dbname, false)
 				Expect(err).ToNot(HaveOccurred())
 			})
 
@@ -337,7 +337,7 @@ var _ = Describe("PostgresEngine", func() {
 
 			BeforeEach(func() {
 				var err error
-				createdUser, createdPassword, err = postgresEngine.CreateUser(bindingID, dbname)
+				createdUser, createdPassword, err = postgresEngine.CreateUser(bindingID, dbname, false)
 				Expect(err).ToNot(HaveOccurred())
 			})
 
@@ -395,7 +395,7 @@ var _ = Describe("PostgresEngine", func() {
 			BeforeEach(func() {
 				var err error
 				postgresEngine.UsernameGenerator = generateUsernameOld
-				createdUser, createdPassword, err = postgresEngine.CreateUser(bindingID, dbname)
+				createdUser, createdPassword, err = postgresEngine.CreateUser(bindingID, dbname, false)
 				postgresEngine.UsernameGenerator = generateUsername
 				Expect(err).ToNot(HaveOccurred())
 			})
@@ -444,7 +444,7 @@ var _ = Describe("PostgresEngine", func() {
 			It("CreateUser() can be called after ResetState()", func() {
 				err := postgresEngine.ResetState()
 				Expect(err).ToNot(HaveOccurred())
-				_, _, err = postgresEngine.CreateUser(bindingID, dbname)
+				_, _, err = postgresEngine.CreateUser(bindingID, dbname, false)
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})
@@ -452,7 +452,7 @@ var _ = Describe("PostgresEngine", func() {
 		Describe("when there was already a user created", func() {
 			BeforeEach(func() {
 				var err error
-				createdUser, createdPassword, err = postgresEngine.CreateUser(bindingID, dbname)
+				createdUser, createdPassword, err = postgresEngine.CreateUser(bindingID, dbname, false)
 				Expect(err).ToNot(HaveOccurred())
 
 				err = postgresEngine.ResetState()
@@ -480,7 +480,7 @@ var _ = Describe("PostgresEngine", func() {
 			})
 
 			It("CreateUser() returns the same user and different password", func() {
-				user, password, err := postgresEngine.CreateUser(bindingID, dbname)
+				user, password, err := postgresEngine.CreateUser(bindingID, dbname, false)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(user).To(Equal(createdUser))
 				Expect(password).ToNot(Equal(createdPassword))

--- a/sqlengine/postgres_engine_test.go
+++ b/sqlengine/postgres_engine_test.go
@@ -296,6 +296,9 @@ var _ = Describe("PostgresEngine", func() {
 				db, err := sql.Open("postgres", connectionString)
 				defer db.Close()
 
+				_, err = db.Exec("CREATE TABLE tbl (col CHAR(8))")
+				Expect(err).ToNot(HaveOccurred())
+
 				_, err = db.Exec("CREATE SCHEMA private")
 				Expect(err).ToNot(HaveOccurred())
 
@@ -317,6 +320,9 @@ var _ = Describe("PostgresEngine", func() {
 				db, err := sql.Open("postgres", connectionString)
 				defer db.Close()
 
+				_, err = db.Exec("DROP TABLE tbl")
+				Expect(err).ToNot(HaveOccurred())
+
 				_, err = db.Exec("DROP TABLE private.tbl")
 				Expect(err).ToNot(HaveOccurred())
 
@@ -333,6 +339,9 @@ var _ = Describe("PostgresEngine", func() {
 				_, err = db.Exec("SELECT * FROM private.tbl")
 				Expect(err).NotTo(HaveOccurred(), "Read only users can SELECT")
 
+				_, err = db.Exec("INSERT INTO private.tbl (col) VALUES ('other')")
+				Expect(err).To(HaveOccurred(), "Read only users cannot INSERT")
+
 				_, err = db.Exec("CREATE TABLE private.anothertbl (col CHAR(8))")
 				Expect(err).To(HaveOccurred(), "Read only users cannot CREATE TABLE")
 
@@ -341,6 +350,15 @@ var _ = Describe("PostgresEngine", func() {
 
 				_, err = db.Exec("DROP SCHEMA private CASCADE")
 				Expect(err).To(HaveOccurred(), "Read only users cannot DROP SCHEMA")
+
+				_, err = db.Exec("SELECT * FROM tbl")
+				Expect(err).NotTo(HaveOccurred(), "Read only users can SELECT in the public schema")
+
+				_, err = db.Exec("INSERT INTO tbl (col) VALUES ('other')")
+				Expect(err).To(HaveOccurred(), "Read only users cannot INSERT in the public schema")
+
+				_, err = db.Exec("CREATE TABLE anothertbl (col CHAR(8))")
+				Expect(err).To(HaveOccurred(), "Read only users cannot CREATE TABLE in the public schema")
 			})
 		})
 

--- a/sqlengine/postgres_engine_test.go
+++ b/sqlengine/postgres_engine_test.go
@@ -364,9 +364,9 @@ var _ = Describe("PostgresEngine", func() {
 			})
 
 			It("CreateUser() returns different user and password", func() {
-				fmt.Sprintf("created user: '%s' Other created user: '%s'", createdUser, otherCreatedUser)
+				By(fmt.Sprintf("created user: '%s' Other created user: '%s'", createdUser, otherCreatedUser))
 				Expect(otherCreatedUser).ToNot(Equal(createdUser))
-				fmt.Sprintf("created user: '%s' Other created user: '%s'", createdUser, otherCreatedUser)
+				By(fmt.Sprintf("created user: '%s' Other created user: '%s'", createdUser, otherCreatedUser))
 				Expect(otherCreatedPassword).ToNot(Equal(createdPassword))
 			})
 

--- a/sqlengine/sql_engine.go
+++ b/sqlengine/sql_engine.go
@@ -15,7 +15,7 @@ const (
 type SQLEngine interface {
 	Open(address string, port int64, dbname string, username string, password string) error
 	Close()
-	CreateUser(bindingID, dbname string) (string, string, error)
+	CreateUser(bindingID, dbname string, readOnly bool) (string, string, error)
 	DropUser(bindingID string) error
 	ResetState() error
 	URI(address string, port int64, dbname string, username string, password string) string


### PR DESCRIPTION
Refer previous discussion in https://github.com/alphagov/paas-rds-broker/pull/117/files

What
---

Uses an event trigger to ensure that `reader`s cannot use the DDL.

How to review
---

Deployed to tlwr dev environment