### PR TITLE
Ensure users can still alter search path

### DIFF
--- a/sqlengine/postgres_engine.go
+++ b/sqlengine/postgres_engine.go
@@ -348,7 +348,7 @@ func (d *PostgresEngine) ensureGroup(tx *sql.Tx, dbname string) error {
 }
 
 const ensurePermissionsTriggersPattern = `
-	create or replace function reassign_owned() returns event_trigger language plpgsql as $$
+	create or replace function reassign_owned() returns event_trigger language plpgsql set search_path to public as $$
 	begin
 		-- do not execute if member of rds_superuser
 		IF EXISTS (select 1 from pg_catalog.pg_roles where rolname = 'rds_superuser')
@@ -371,7 +371,7 @@ const ensurePermissionsTriggersPattern = `
 		RETURN;
 	end
 	$$;
-	create or replace function make_readable_generic() returns void language plpgsql as $$
+	create or replace function make_readable_generic() returns void language plpgsql set search_path to public as $$
 	declare
 		r record;
 	begin
@@ -406,13 +406,13 @@ const ensurePermissionsTriggersPattern = `
 		RETURN;
 	end
 	$$;
-	create or replace function make_readable() returns event_trigger language plpgsql as $$
+	create or replace function make_readable() returns event_trigger language plpgsql set search_path to public as $$
 	begin
 		EXECUTE 'select make_readable_generic()';
 		RETURN;
 	end
 	$$;
-	create or replace function forbid_ddl_reader() returns event_trigger language plpgsql as $$
+	create or replace function forbid_ddl_reader() returns event_trigger language plpgsql set search_path to public as $$
 	begin
 		-- do not execute if member of rds_superuser
 		IF EXISTS (select 1 from pg_catalog.pg_roles where rolname = 'rds_superuser')

--- a/sqlengine/postgres_engine_test.go
+++ b/sqlengine/postgres_engine_test.go
@@ -424,7 +424,7 @@ var _ = Describe("PostgresEngine", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			It("creates a user which can only select", func() {
+			It("can still create and insert with a restricted search path", func() {
 				connectionString := postgresEngine.URI(address, port, dbname, createdUser, createdPassword)
 				db, err := sql.Open("postgres", connectionString)
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
What
---

We use triggers to set up permissions and deny access to certain users.

We recently added a read-only feature which relies more heavily on event triggers.

These event triggers did not specify the search path within the function, which meant that if [a user altered the search path](https://github.com/frankhommers/Hangfire.PostgreSql/blob/cbae6eba7299c09195f4a0330eae057e86a246cd/src/Hangfire.PostgreSql/Scripts/Install.v10.sql#L1) then the triggers would prevent them from using the database.

This commit adds a test that alters the search path, and then explicit ensures that the search path is set correctly for those functions.

How to review
---

Check `env=tlwr` / `org=dfe` / `space=postgres` / `app=sf_test` app is starting and connecting to a database

Code review