### PR TITLE
[#174442198] allow a user to upgrade their instance to the latest minor version

### DIFF
--- a/awsrds/db_instance.go
+++ b/awsrds/db_instance.go
@@ -32,6 +32,7 @@ type RDSInstance interface {
 	GetParameterGroup(groupId string) (*rds.DBParameterGroup, error)
 	CreateParameterGroup(input *rds.CreateDBParameterGroupInput) error
 	ModifyParameterGroup(input *rds.ModifyDBParameterGroupInput) error
+	GetLatestMinorVersion(engine string, version string) (*string, error)
 }
 
 type ByCreateTime []*rds.DBSnapshot

--- a/awsrds/fakes/fake_rds_instance.go
+++ b/awsrds/fakes/fake_rds_instance.go
@@ -108,6 +108,20 @@ type FakeRDSInstance struct {
 		result1 []*rds.DBSnapshot
 		result2 error
 	}
+	GetLatestMinorVersionStub        func(string, string) (*string, error)
+	getLatestMinorVersionMutex       sync.RWMutex
+	getLatestMinorVersionArgsForCall []struct {
+		arg1 string
+		arg2 string
+	}
+	getLatestMinorVersionReturns struct {
+		result1 *string
+		result2 error
+	}
+	getLatestMinorVersionReturnsOnCall map[int]struct {
+		result1 *string
+		result2 error
+	}
 	GetParameterGroupStub        func(string) (*rds.DBParameterGroup, error)
 	getParameterGroupMutex       sync.RWMutex
 	getParameterGroupArgsForCall []struct {
@@ -710,6 +724,70 @@ func (fake *FakeRDSInstance) DescribeSnapshotsReturnsOnCall(i int, result1 []*rd
 	}{result1, result2}
 }
 
+func (fake *FakeRDSInstance) GetLatestMinorVersion(arg1 string, arg2 string) (*string, error) {
+	fake.getLatestMinorVersionMutex.Lock()
+	ret, specificReturn := fake.getLatestMinorVersionReturnsOnCall[len(fake.getLatestMinorVersionArgsForCall)]
+	fake.getLatestMinorVersionArgsForCall = append(fake.getLatestMinorVersionArgsForCall, struct {
+		arg1 string
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("GetLatestMinorVersion", []interface{}{arg1, arg2})
+	fake.getLatestMinorVersionMutex.Unlock()
+	if fake.GetLatestMinorVersionStub != nil {
+		return fake.GetLatestMinorVersionStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.getLatestMinorVersionReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeRDSInstance) GetLatestMinorVersionCallCount() int {
+	fake.getLatestMinorVersionMutex.RLock()
+	defer fake.getLatestMinorVersionMutex.RUnlock()
+	return len(fake.getLatestMinorVersionArgsForCall)
+}
+
+func (fake *FakeRDSInstance) GetLatestMinorVersionCalls(stub func(string, string) (*string, error)) {
+	fake.getLatestMinorVersionMutex.Lock()
+	defer fake.getLatestMinorVersionMutex.Unlock()
+	fake.GetLatestMinorVersionStub = stub
+}
+
+func (fake *FakeRDSInstance) GetLatestMinorVersionArgsForCall(i int) (string, string) {
+	fake.getLatestMinorVersionMutex.RLock()
+	defer fake.getLatestMinorVersionMutex.RUnlock()
+	argsForCall := fake.getLatestMinorVersionArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeRDSInstance) GetLatestMinorVersionReturns(result1 *string, result2 error) {
+	fake.getLatestMinorVersionMutex.Lock()
+	defer fake.getLatestMinorVersionMutex.Unlock()
+	fake.GetLatestMinorVersionStub = nil
+	fake.getLatestMinorVersionReturns = struct {
+		result1 *string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeRDSInstance) GetLatestMinorVersionReturnsOnCall(i int, result1 *string, result2 error) {
+	fake.getLatestMinorVersionMutex.Lock()
+	defer fake.getLatestMinorVersionMutex.Unlock()
+	fake.GetLatestMinorVersionStub = nil
+	if fake.getLatestMinorVersionReturnsOnCall == nil {
+		fake.getLatestMinorVersionReturnsOnCall = make(map[int]struct {
+			result1 *string
+			result2 error
+		})
+	}
+	fake.getLatestMinorVersionReturnsOnCall[i] = struct {
+		result1 *string
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeRDSInstance) GetParameterGroup(arg1 string) (*rds.DBParameterGroup, error) {
 	fake.getParameterGroupMutex.Lock()
 	ret, specificReturn := fake.getParameterGroupReturnsOnCall[len(fake.getParameterGroupArgsForCall)]
@@ -1224,6 +1302,8 @@ func (fake *FakeRDSInstance) Invocations() map[string][][]interface{} {
 	defer fake.describeByTagMutex.RUnlock()
 	fake.describeSnapshotsMutex.RLock()
 	defer fake.describeSnapshotsMutex.RUnlock()
+	fake.getLatestMinorVersionMutex.RLock()
+	defer fake.getLatestMinorVersionMutex.RUnlock()
 	fake.getParameterGroupMutex.RLock()
 	defer fake.getParameterGroupMutex.RUnlock()
 	fake.getResourceTagsMutex.RLock()

--- a/awsrds/rds_db_instance.go
+++ b/awsrds/rds_db_instance.go
@@ -447,10 +447,15 @@ func (r *RDSDBInstance) selectEngineVersion(engine *string, oldEngineVersion *st
 		if oldEngineVersionSlice[0] == planEngineVersionSlice[0] {
 			keepEngineVersion = true
 		}
-	}
-	if len(planEngineVersionSlice) >= 2 {
+	} else if len(planEngineVersionSlice) == 2 {
 		if oldEngineVersionSlice[0] == planEngineVersionSlice[0] &&
 			oldEngineVersionSlice[1] == planEngineVersionSlice[1] {
+			keepEngineVersion = true
+		}
+	} else if len(planEngineVersionSlice) == 3 {
+		if oldEngineVersionSlice[0] == planEngineVersionSlice[0] &&
+			oldEngineVersionSlice[1] == planEngineVersionSlice[1] &&
+			oldEngineVersionSlice[2] == planEngineVersionSlice[2] {
 			keepEngineVersion = true
 		}
 	}

--- a/awsrds/rds_db_instance_test.go
+++ b/awsrds/rds_db_instance_test.go
@@ -689,7 +689,7 @@ var _ = Describe("RDS DB Instance", func() {
 		It("keeps EngineVersion if new major and minor version match", func() {
 			modifyDBInstanceInput := &rds.ModifyDBInstanceInput{
 				DBInstanceIdentifier: aws.String(dbInstanceIdentifier),
-				EngineVersion:        aws.String("1.2.1"),
+				EngineVersion:        aws.String("1.2.3"),
 			}
 
 			_, err := rdsDBInstance.Modify(modifyDBInstanceInput)

--- a/awsrds/rds_db_instance_test.go
+++ b/awsrds/rds_db_instance_test.go
@@ -719,6 +719,17 @@ var _ = Describe("RDS DB Instance", func() {
 			Expect(receivedModifyDBInstanceInput.EngineVersion).To(Equal(aws.String("1.3.1")))
 		})
 
+		It("sets EngineVersion if new patch version differs", func() {
+			modifyDBInstanceInput := &rds.ModifyDBInstanceInput{
+				DBInstanceIdentifier: aws.String(dbInstanceIdentifier),
+				EngineVersion:        aws.String("1.2.4"),
+			}
+
+			_, err := rdsDBInstance.Modify(modifyDBInstanceInput)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(receivedModifyDBInstanceInput.EngineVersion).To(Equal(aws.String("1.2.4")))
+		})
+
 		It("sets AllowMajorVersionUpgrade to true by default", func() {
 			modifyDBInstanceInput := &rds.ModifyDBInstanceInput{
 				DBInstanceIdentifier:     aws.String(dbInstanceIdentifier),

--- a/rdsbroker/parameters.go
+++ b/rdsbroker/parameters.go
@@ -15,15 +15,16 @@ type ProvisionParameters struct {
 }
 
 type UpdateParameters struct {
-	ApplyAtMaintenanceWindow   bool     `json:"apply_at_maintenance_window"`
-	BackupRetentionPeriod      int64    `json:"backup_retention_period"`
-	PreferredBackupWindow      string   `json:"preferred_backup_window"`
-	PreferredMaintenanceWindow string   `json:"preferred_maintenance_window"`
-	SkipFinalSnapshot          *bool    `json:"skip_final_snapshot"`
-	Reboot                     *bool    `json:"reboot"`
-	ForceFailover              *bool    `json:"force_failover"`
-	EnableExtensions           []string `json:"enable_extensions"`
-	DisableExtensions          []string `json:"disable_extensions"`
+	ApplyAtMaintenanceWindow    bool     `json:"apply_at_maintenance_window"`
+	BackupRetentionPeriod       int64    `json:"backup_retention_period"`
+	PreferredBackupWindow       string   `json:"preferred_backup_window"`
+	PreferredMaintenanceWindow  string   `json:"preferred_maintenance_window"`
+	SkipFinalSnapshot           *bool    `json:"skip_final_snapshot"`
+	Reboot                      *bool    `json:"reboot"`
+	UpgradeMinorVersionToLatest *bool    `json:"update_minor_version_to_latest"`
+	ForceFailover               *bool    `json:"force_failover"`
+	EnableExtensions            []string `json:"enable_extensions"`
+	DisableExtensions           []string `json:"disable_extensions"`
 }
 
 type BindParameters struct {


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/n/projects/1275640/stories/174442198)

What
---

As a user, I want to `cf update-service` to the latest minor version,
so that my database has non-critical CVE patches on-demand.

How to review
---

- Deploy this to your development environment
- Ensure the related PR is applied, so the broker has IAM permissions to check DB versions
- Upgrade a DB instance (eg `admin/billing/accounts-db`) using `cf update-service accounts-db -c '{"update_minor_version_to_latest": true}'`

Requires
---

https://github.com/alphagov/paas-aws-account-wide-terraform/pull/232