### PR TITLE
[#175373731] Allow our users to restore from a point in time

### DIFF
--- a/awsrds/db_instance.go
+++ b/awsrds/db_instance.go
@@ -23,6 +23,7 @@ type RDSInstance interface {
 	DeleteSnapshots(brokerName string, keepForDays int) error
 	Create(createDBInstanceInput *rds.CreateDBInstanceInput) error
 	Restore(restoreRBInstanceInput *rds.RestoreDBInstanceFromDBSnapshotInput) error
+	RestoreToPointInTime(restoreRBInstanceInput *rds.RestoreDBInstanceToPointInTimeInput) error
 	Modify(modifyDBInstanceInput *rds.ModifyDBInstanceInput) (*rds.DBInstance, error)
 	AddTagsToResource(resourceArn string, tags []*rds.Tag) error
 	Reboot(rebootDBInstanceInput *rds.RebootDBInstanceInput) error

--- a/awsrds/fakes/fake_rds_instance.go
+++ b/awsrds/fakes/fake_rds_instance.go
@@ -221,6 +221,17 @@ type FakeRDSInstance struct {
 	restoreReturnsOnCall map[int]struct {
 		result1 error
 	}
+	RestoreToPointInTimeStub        func(*rds.RestoreDBInstanceToPointInTimeInput) error
+	restoreToPointInTimeMutex       sync.RWMutex
+	restoreToPointInTimeArgsForCall []struct {
+		arg1 *rds.RestoreDBInstanceToPointInTimeInput
+	}
+	restoreToPointInTimeReturns struct {
+		result1 error
+	}
+	restoreToPointInTimeReturnsOnCall map[int]struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -1283,6 +1294,66 @@ func (fake *FakeRDSInstance) RestoreReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *FakeRDSInstance) RestoreToPointInTime(arg1 *rds.RestoreDBInstanceToPointInTimeInput) error {
+	fake.restoreToPointInTimeMutex.Lock()
+	ret, specificReturn := fake.restoreToPointInTimeReturnsOnCall[len(fake.restoreToPointInTimeArgsForCall)]
+	fake.restoreToPointInTimeArgsForCall = append(fake.restoreToPointInTimeArgsForCall, struct {
+		arg1 *rds.RestoreDBInstanceToPointInTimeInput
+	}{arg1})
+	fake.recordInvocation("RestoreToPointInTime", []interface{}{arg1})
+	fake.restoreToPointInTimeMutex.Unlock()
+	if fake.RestoreToPointInTimeStub != nil {
+		return fake.RestoreToPointInTimeStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.restoreToPointInTimeReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeRDSInstance) RestoreToPointInTimeCallCount() int {
+	fake.restoreToPointInTimeMutex.RLock()
+	defer fake.restoreToPointInTimeMutex.RUnlock()
+	return len(fake.restoreToPointInTimeArgsForCall)
+}
+
+func (fake *FakeRDSInstance) RestoreToPointInTimeCalls(stub func(*rds.RestoreDBInstanceToPointInTimeInput) error) {
+	fake.restoreToPointInTimeMutex.Lock()
+	defer fake.restoreToPointInTimeMutex.Unlock()
+	fake.RestoreToPointInTimeStub = stub
+}
+
+func (fake *FakeRDSInstance) RestoreToPointInTimeArgsForCall(i int) *rds.RestoreDBInstanceToPointInTimeInput {
+	fake.restoreToPointInTimeMutex.RLock()
+	defer fake.restoreToPointInTimeMutex.RUnlock()
+	argsForCall := fake.restoreToPointInTimeArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeRDSInstance) RestoreToPointInTimeReturns(result1 error) {
+	fake.restoreToPointInTimeMutex.Lock()
+	defer fake.restoreToPointInTimeMutex.Unlock()
+	fake.RestoreToPointInTimeStub = nil
+	fake.restoreToPointInTimeReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeRDSInstance) RestoreToPointInTimeReturnsOnCall(i int, result1 error) {
+	fake.restoreToPointInTimeMutex.Lock()
+	defer fake.restoreToPointInTimeMutex.Unlock()
+	fake.RestoreToPointInTimeStub = nil
+	if fake.restoreToPointInTimeReturnsOnCall == nil {
+		fake.restoreToPointInTimeReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.restoreToPointInTimeReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeRDSInstance) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -1320,6 +1391,8 @@ func (fake *FakeRDSInstance) Invocations() map[string][][]interface{} {
 	defer fake.removeTagMutex.RUnlock()
 	fake.restoreMutex.RLock()
 	defer fake.restoreMutex.RUnlock()
+	fake.restoreToPointInTimeMutex.RLock()
+	defer fake.restoreToPointInTimeMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/awsrds/rds_db_instance.go
+++ b/awsrds/rds_db_instance.go
@@ -21,6 +21,8 @@ const (
 	TagRestoredFromSnapshot = "Restored From Snapshot"
 	TagBrokerName           = "Broker Name"
 	TagExtensions           = "Extensions"
+	TagOriginDatabase       = "Restored From Database"
+	TagOriginPointInTime    = "Restored From Time"
 )
 
 type RDSDBInstance struct {

--- a/awsrds/rds_db_instance.go
+++ b/awsrds/rds_db_instance.go
@@ -250,6 +250,18 @@ func (r *RDSDBInstance) Restore(restoreDBInstanceInput *rds.RestoreDBInstanceFro
 	return nil
 }
 
+func (r *RDSDBInstance) RestoreToPointInTime(restoreDBInstanceInput *rds.RestoreDBInstanceToPointInTimeInput) error {
+	r.logger.Debug("restore-db-instance-to-point-in-time", lager.Data{"input": &restoreDBInstanceInput})
+
+	restoreDBInstanceOutput, err := r.rdssvc.RestoreDBInstanceToPointInTime(restoreDBInstanceInput)
+	if err != nil {
+		return HandleAWSError(err, r.logger)
+	}
+	r.logger.Debug("restore-db-instance-to-point-in-time", lager.Data{"output": restoreDBInstanceOutput})
+
+	return nil
+}
+
 func (r *RDSDBInstance) Modify(modifyDBInstanceInput *rds.ModifyDBInstanceInput) (*rds.DBInstance, error) {
 	sanitizedDBInstanceInput := *modifyDBInstanceInput
 	sanitizedDBInstanceInput.MasterUserPassword = aws.String("REDACTED")

--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -1307,7 +1307,7 @@ func (b *RDSBroker) restoreDBInstancePointInTimeInput(instanceID, originDBIdenti
 		tags.OriginPointInTime = originTime.Format(time.RFC3339)
 	}
 
-	return &rds.RestoreDBInstanceToPointInTimeInput{
+	input := &rds.RestoreDBInstanceToPointInTimeInput{
 		SourceDBInstanceIdentifier: aws.String(b.dbInstanceIdentifier(originDBIdentifier)),
 		TargetDBInstanceIdentifier: aws.String(b.dbInstanceIdentifier(instanceID)),
 		RestoreTime:                originTime,
@@ -1326,7 +1326,15 @@ func (b *RDSBroker) restoreDBInstancePointInTimeInput(instanceID, originDBIdenti
 		Port:                       servicePlan.RDSProperties.Port,
 		StorageType:                servicePlan.RDSProperties.StorageType,
 		Tags:                       awsrds.BuilRDSTags(b.dbTags(tags)),
-	}, nil
+	}
+
+	if originTime != nil {
+		input.RestoreTime = originTime
+	} else {
+		input.UseLatestRestorableTime = aws.Bool(true)
+	}
+
+	return input, nil
 }
 
 func (b *RDSBroker) newModifyDBInstanceInput(instanceID string, servicePlan ServicePlan, updateParameters UpdateParameters, parameterGroupName string) *rds.ModifyDBInstanceInput {

--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -281,14 +281,15 @@ func (b *RDSBroker) restoreFromPointInTime(
 
 	restoreFromDBInstanceID := *provisionParameters.RestoreFromPointInTimeOf
 
-	_, err := b.dbInstance.Describe(b.dbInstanceIdentifier(restoreFromDBInstanceID))
+	existingInstance, err := b.dbInstance.Describe(b.dbInstanceIdentifier(restoreFromDBInstanceID))
 	if err != nil {
 		return fmt.Errorf("Cannot find instance %s", b.dbInstanceIdentifier(restoreFromDBInstanceID))
 	}
 
-	tags, err := b.dbInstance.GetResourceTags(b.dbInstanceIdentifier(restoreFromDBInstanceID))
+	dbARN := *(existingInstance.DBInstanceArn)
+	tags, err := b.dbInstance.GetResourceTags(dbARN)
 	if err != nil {
-		return fmt.Errorf("Cannot find instance %s", b.dbInstanceIdentifier(restoreFromDBInstanceID))
+		return fmt.Errorf("Cannot find instance %s", dbARN)
 	}
 
 	tagsByName := awsrds.RDSTagsValues(tags)

--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -193,6 +193,10 @@ func (b *RDSBroker) Provision(
 		}
 	}
 
+	if provisionParameters.RestoreFromLatestSnapshotOf != nil && provisionParameters.RestoreToPointInTimeOf != nil {
+		return brokerapi.ProvisionedServiceSpec{}, fmt.Errorf("Cannot use both restore_from_latest_snapshot_of and restore_to_point_in_time_of at the same time")
+	}
+
 	if provisionParameters.RestoreFromLatestSnapshotOf == nil && provisionParameters.RestoreFromLatestSnapshotBefore != nil {
 		return brokerapi.ProvisionedServiceSpec{}, fmt.Errorf("Parameter restore_from_latest_snapshot_before should be used with restore_from_latest_snapshot_of")
 	}

--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -210,6 +210,9 @@ func (b *RDSBroker) Provision(
 			return brokerapi.ProvisionedServiceSpec{}, err
 		}
 	} else if provisionParameters.RestoreFromPointInTimeOf != nil {
+		if servicePlan.RDSProperties.Engine != nil && *servicePlan.RDSProperties.Engine != "postgres" {
+			return brokerapi.ProvisionedServiceSpec{}, fmt.Errorf("Restore from snapshot not supported for engine '%s'", *servicePlan.RDSProperties.Engine)
+		}
 	} else {
 		if *provisionParameters.RestoreFromLatestSnapshotOf == "" {
 			return brokerapi.ProvisionedServiceSpec{}, fmt.Errorf("Invalid guid: '%s'", *provisionParameters.RestoreFromLatestSnapshotOf)

--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -213,6 +213,9 @@ func (b *RDSBroker) Provision(
 		if servicePlan.RDSProperties.Engine != nil && *servicePlan.RDSProperties.Engine != "postgres" {
 			return brokerapi.ProvisionedServiceSpec{}, fmt.Errorf("Restore from snapshot not supported for engine '%s'", *servicePlan.RDSProperties.Engine)
 		}
+		if *provisionParameters.RestoreFromPointInTimeOf == "" {
+			return brokerapi.ProvisionedServiceSpec{}, fmt.Errorf("Invalid guid: '%s'", *provisionParameters.RestoreFromPointInTimeOf)
+		}
 	} else {
 		if *provisionParameters.RestoreFromLatestSnapshotOf == "" {
 			return brokerapi.ProvisionedServiceSpec{}, fmt.Errorf("Invalid guid: '%s'", *provisionParameters.RestoreFromLatestSnapshotOf)

--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -216,6 +216,11 @@ func (b *RDSBroker) Provision(
 		if *provisionParameters.RestoreFromPointInTimeOf == "" {
 			return brokerapi.ProvisionedServiceSpec{}, fmt.Errorf("Invalid guid: '%s'", *provisionParameters.RestoreFromPointInTimeOf)
 		}
+		restoreFromDBInstanceID := b.dbInstanceIdentifier(*provisionParameters.RestoreFromPointInTimeOf)
+		_, err := b.dbInstance.Describe(b.dbInstanceIdentifier(restoreFromDBInstanceID))
+		if err != nil {
+			return brokerapi.ProvisionedServiceSpec{}, fmt.Errorf("Cannot find instance %s", restoreFromDBInstanceID)
+		}
 	} else {
 		if *provisionParameters.RestoreFromLatestSnapshotOf == "" {
 			return brokerapi.ProvisionedServiceSpec{}, fmt.Errorf("Invalid guid: '%s'", *provisionParameters.RestoreFromLatestSnapshotOf)

--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -193,8 +193,8 @@ func (b *RDSBroker) Provision(
 		}
 	}
 
-	if provisionParameters.RestoreFromLatestSnapshotOf != nil && provisionParameters.RestoreToPointInTimeOf != nil {
-		return brokerapi.ProvisionedServiceSpec{}, fmt.Errorf("Cannot use both restore_from_latest_snapshot_of and restore_to_point_in_time_of at the same time")
+	if provisionParameters.RestoreFromLatestSnapshotOf != nil && provisionParameters.RestoreFromPointInTimeOf != nil {
+		return brokerapi.ProvisionedServiceSpec{}, fmt.Errorf("Cannot use both restore_from_latest_snapshot_of and restore_from_point_in_time_of at the same time")
 	}
 
 	if provisionParameters.RestoreFromLatestSnapshotOf == nil && provisionParameters.RestoreFromLatestSnapshotBefore != nil {

--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -201,7 +201,7 @@ func (b *RDSBroker) Provision(
 		return brokerapi.ProvisionedServiceSpec{}, fmt.Errorf("Parameter restore_from_latest_snapshot_before should be used with restore_from_latest_snapshot_of")
 	}
 
-	if provisionParameters.RestoreFromLatestSnapshotOf == nil {
+	if provisionParameters.RestoreFromLatestSnapshotOf == nil && provisionParameters.RestoreFromPointInTimeOf == nil {
 		createDBInstance, err := b.newCreateDBInstanceInput(instanceID, servicePlan, provisionParameters, details)
 		if err != nil {
 			return brokerapi.ProvisionedServiceSpec{}, err
@@ -209,6 +209,7 @@ func (b *RDSBroker) Provision(
 		if err := b.dbInstance.Create(createDBInstance); err != nil {
 			return brokerapi.ProvisionedServiceSpec{}, err
 		}
+	} else if provisionParameters.RestoreFromPointInTimeOf != nil {
 	} else {
 		if *provisionParameters.RestoreFromLatestSnapshotOf == "" {
 			return brokerapi.ProvisionedServiceSpec{}, fmt.Errorf("Invalid guid: '%s'", *provisionParameters.RestoreFromLatestSnapshotOf)

--- a/rdsbroker/broker_test.go
+++ b/rdsbroker/broker_test.go
@@ -427,10 +427,24 @@ var _ = Describe("RDS Broker", func() {
 				BeforeEach(func() {
 					provisionDetails.RawParameters = json.RawMessage(`{"restore_from_point_in_time_of": ""}`)
 				})
+
 				It("returns the correct error", func() {
 					_, err := rdsBroker.Provision(ctx, instanceID, provisionDetails, acceptsIncomplete)
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).Should(ContainSubstring("Invalid guid"))
+				})
+			})
+
+			Context("and the instance does not exist", func() {
+				BeforeEach(func() {
+					provisionDetails.RawParameters = json.RawMessage(`{"restore_from_point_in_time_of": "a-guid"}`)
+					rdsInstance.DescribeReturns(nil, awsrds.ErrDBInstanceDoesNotExist)
+				})
+
+				It("returns the correct error", func() {
+					_, err := rdsBroker.Provision(ctx, instanceID, provisionDetails, acceptsIncomplete)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).Should(ContainSubstring("Cannot find instance cf-a-guid"))
 				})
 			})
 		})

--- a/rdsbroker/broker_test.go
+++ b/rdsbroker/broker_test.go
@@ -393,6 +393,20 @@ var _ = Describe("RDS Broker", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
+		Context("when restoring to a point in time", func() {
+			Context("and the restore_from_latest_snapshot_of also present", func() {
+				BeforeEach(func() {
+					provisionDetails.RawParameters = json.RawMessage(`{"restore_from_latest_snapshot_of": "abc", "restore_to_point_in_time_of": "def"}`)
+				})
+
+				It("returns the correct error", func() {
+					_, err := rdsBroker.Provision(ctx, instanceID, provisionDetails, acceptsIncomplete)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).Should(ContainSubstring("Cannot use both restore_from_latest_snapshot_of and restore_to_point_in_time_of at the same time"))
+				})
+			})
+		})
+
 		Context("when restoring from a snapshot", func() {
 			var (
 				restoreFromSnapshotInstanceGUID  string

--- a/rdsbroker/broker_test.go
+++ b/rdsbroker/broker_test.go
@@ -511,6 +511,7 @@ var _ = Describe("RDS Broker", func() {
 				Expect(aws.StringValue(input.DBInstanceClass)).To(Equal("db.m1.test"))
 				Expect(aws.StringValue(input.Engine)).To(Equal("postgres"))
 				Expect(aws.StringValue(input.DBName)).To(BeEmpty())
+				Expect(aws.BoolValue(input.UseLatestRestorableTime)).To(Equal(true))
 				Expect(err).ToNot(HaveOccurred())
 			})
 
@@ -558,6 +559,7 @@ var _ = Describe("RDS Broker", func() {
 					Expect(aws.StringValue(input.TargetDBInstanceIdentifier)).To(Equal(dbInstanceIdentifier))
 					Expect(aws.StringValue(input.SourceDBInstanceIdentifier)).To(Equal(restoreFromPointInTimeDBInstanceID))
 					Expect(aws.TimeValue(input.RestoreTime)).To(BeTemporally("~", restoreTime, 1*time.Second))
+					Expect(input.UseLatestRestorableTime).To(BeNil())
 					Expect(err).ToNot(HaveOccurred())
 				})
 

--- a/rdsbroker/broker_test.go
+++ b/rdsbroker/broker_test.go
@@ -405,6 +405,19 @@ var _ = Describe("RDS Broker", func() {
 					Expect(err.Error()).Should(ContainSubstring("Cannot use both restore_from_latest_snapshot_of and restore_from_point_in_time_of at the same time"))
 				})
 			})
+
+			Context("when the engine is not 'postgres'", func() {
+				BeforeEach(func() {
+					rdsProperties1.Engine = stringPointer("some-other-engine")
+					provisionDetails.RawParameters = json.RawMessage(`{"restore_from_point_in_time_of": "a-guid"}`)
+				})
+
+				It("returns the correct error", func() {
+					_, err := rdsBroker.Provision(ctx, instanceID, provisionDetails, acceptsIncomplete)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).Should(ContainSubstring("not supported for engine"))
+				})
+			})
 		})
 
 		Context("when restoring from a snapshot", func() {

--- a/rdsbroker/broker_test.go
+++ b/rdsbroker/broker_test.go
@@ -393,16 +393,16 @@ var _ = Describe("RDS Broker", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		Context("when restoring to a point in time", func() {
+		Context("when restoring from a point in time", func() {
 			Context("and the restore_from_latest_snapshot_of also present", func() {
 				BeforeEach(func() {
-					provisionDetails.RawParameters = json.RawMessage(`{"restore_from_latest_snapshot_of": "abc", "restore_to_point_in_time_of": "def"}`)
+					provisionDetails.RawParameters = json.RawMessage(`{"restore_from_latest_snapshot_of": "abc", "restore_from_point_in_time_of": "def"}`)
 				})
 
 				It("returns the correct error", func() {
 					_, err := rdsBroker.Provision(ctx, instanceID, provisionDetails, acceptsIncomplete)
 					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).Should(ContainSubstring("Cannot use both restore_from_latest_snapshot_of and restore_to_point_in_time_of at the same time"))
+					Expect(err.Error()).Should(ContainSubstring("Cannot use both restore_from_latest_snapshot_of and restore_from_point_in_time_of at the same time"))
 				})
 			})
 		})

--- a/rdsbroker/broker_test.go
+++ b/rdsbroker/broker_test.go
@@ -394,6 +394,10 @@ var _ = Describe("RDS Broker", func() {
 		})
 
 		Context("when restoring from a point in time", func() {
+			BeforeEach(func() {
+				rdsProperties1.Engine = stringPointer("postgres")
+			})
+
 			Context("and the restore_from_latest_snapshot_of also present", func() {
 				BeforeEach(func() {
 					provisionDetails.RawParameters = json.RawMessage(`{"restore_from_latest_snapshot_of": "abc", "restore_from_point_in_time_of": "def"}`)
@@ -416,6 +420,17 @@ var _ = Describe("RDS Broker", func() {
 					_, err := rdsBroker.Provision(ctx, instanceID, provisionDetails, acceptsIncomplete)
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).Should(ContainSubstring("not supported for engine"))
+				})
+			})
+
+			Context("and the restore_from_point_in_time_of is an empty string", func() {
+				BeforeEach(func() {
+					provisionDetails.RawParameters = json.RawMessage(`{"restore_from_point_in_time_of": ""}`)
+				})
+				It("returns the correct error", func() {
+					_, err := rdsBroker.Provision(ctx, instanceID, provisionDetails, acceptsIncomplete)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).Should(ContainSubstring("Invalid guid"))
 				})
 			})
 		})

--- a/rdsbroker/parameters.go
+++ b/rdsbroker/parameters.go
@@ -9,6 +9,8 @@ type ProvisionParameters struct {
 	PreferredBackupWindow           string   `json:"preferred_backup_window"`
 	PreferredMaintenanceWindow      string   `json:"preferred_maintenance_window"`
 	SkipFinalSnapshot               *bool    `json:"skip_final_snapshot"`
+	RestoreToPointInTimeOf          *string  `json:"restore_to_point_in_time_of"`
+	RestoreToPointInTimeBefore      *string  `json:"restore_to_point_in_time_before"`
 	RestoreFromLatestSnapshotOf     *string  `json:"restore_from_latest_snapshot_of"`
 	RestoreFromLatestSnapshotBefore *string  `json:"restore_from_latest_snapshot_before"`
 	Extensions                      []string `json:"enable_extensions"`

--- a/rdsbroker/parameters.go
+++ b/rdsbroker/parameters.go
@@ -9,8 +9,8 @@ type ProvisionParameters struct {
 	PreferredBackupWindow           string   `json:"preferred_backup_window"`
 	PreferredMaintenanceWindow      string   `json:"preferred_maintenance_window"`
 	SkipFinalSnapshot               *bool    `json:"skip_final_snapshot"`
-	RestoreToPointInTimeOf          *string  `json:"restore_to_point_in_time_of"`
-	RestoreToPointInTimeBefore      *string  `json:"restore_to_point_in_time_before"`
+	RestoreFromPointInTimeOf        *string  `json:"restore_from_point_in_time_of"`
+	RestoreFromPointInTimeBefore    *string  `json:"restore_from_point_in_time_before"`
 	RestoreFromLatestSnapshotOf     *string  `json:"restore_from_latest_snapshot_of"`
 	RestoreFromLatestSnapshotBefore *string  `json:"restore_from_latest_snapshot_before"`
 	Extensions                      []string `json:"enable_extensions"`


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/175373731)

What
----

- adds create parameter `restore_from_point_in_time_of` which is a guid source database
- adds create parameter `restore_from_point_in_time_before` which is a UTC date/time

As a user I want to be able to restore (create new database) a Postgres from an existing one using AWS RDS point-in-time recovery, using either the latest value or a specific time

How to review
----

Deploy to your development environment

Create a database (not tiny) and add some things, eg over the course of 1 hour

Use the feature to create a new database, in between when you started adding things and now

Check that it works