### PR TITLE
Stop unnecessary connection when updating Postgres

### DIFF
--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -871,7 +871,7 @@ func (b *RDSBroker) ensureDropExtensions(instanceID string, dbInstance *rds.DBIn
 		instanceIDLogKey: instanceID,
 	})
 
-	if aws.StringValue(dbInstance.Engine) == "postgres" {
+	if aws.StringValue(dbInstance.Engine) == "postgres" && len(extensions) > 0 {
 		dbName := b.dbNameFromDBInstance(instanceID, dbInstance)
 		sqlEngine, err := b.openSQLEngineForDBInstance(instanceID, dbName, dbInstance)
 		if err != nil {


### PR DESCRIPTION
## What

A tenant has completely filled up their RDS Postgres instance and wants to upgrade to a larger plan. The broker should be able to handle this fine, but it doesn't in practice. In practice the broker is failing to process the update, because it errors when it can't connect to the Postgres instance.

This PR removes a situation where the RDS Broker connects to Postgres instances even when there is no work to be done. I'm not certain that this is the only reason changing plan is failing, but it's at least one of the reasons.

This relates to [ZenDesk #4294398](https://govuk.zendesk.com/agent/tickets/4294398). I'm going to solve that manually rather than do all the multi-repo work of getting this PR pushed out, but it's a nice change that should be picked up when we next work on the RDS Broker.

## How to review

* See if the testsuite passes
* Code review