### PR TITLE
Adding support for Postgres 12.

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -60,6 +60,10 @@ jobs:
         run: |
           make start_postgres_11 run_postgres_sql_tests stop_postgres_11
 
+      - name: Run postgres 12 tests
+        run: |
+          make start_postgres_12 run_postgres_sql_tests stop_postgres_12
+
       - name: Run mysql 8.0
         run: |
           make start_mysql_80 run_mysql_sql_tests stop_mysql_80

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ test_unit:
 .PHONY: test_all_sql
 test_all_sql: test_postgres test_mysql
 .PHONY: test_postgres
-test_postgres: start_postgres_9 run_postgres_sql_tests stop_postgres_9 start_postgres_10 run_postgres_sql_tests stop_postgres_10 start_postgres_11 run_postgres_sql_tests stop_postgres_11
+test_postgres: start_postgres_9 run_postgres_sql_tests stop_postgres_9 start_postgres_10 run_postgres_sql_tests stop_postgres_10 start_postgres_11 run_postgres_sql_tests stop_postgres_11 start_postgres_12 run_postgres_sql_tests stop_postgres_12
 .PHONY: test_mysql
 test_mysql: start_mysql_80 run_mysql_sql_tests stop_mysql_80 start_mysql_57 run_mysql_sql_tests stop_mysql_57
 
@@ -41,6 +41,11 @@ start_postgres_11:
 	docker run -p 5432:5432 --name postgres-11 -e POSTGRES_PASSWORD=$(POSTGRESQL_PASSWORD) -d postgres:11.5; \
 	sleep 5
 
+.PHONY: start_postgres_12
+start_postgres_12:
+	docker run -p 5432:5432 --name postgres-12 -e POSTGRES_PASSWORD=$(POSTGRESQL_PASSWORD) -d postgres:12.5; \
+	sleep 5
+
 .PHONY: stop_postgres_9
 stop_postgres_9:
 	docker rm -f postgres-9
@@ -52,6 +57,10 @@ stop_postgres_10:
 .PHONY: stop_postgres_11
 stop_postgres_11:
 	docker rm -f postgres-11
+
+.PHONY: stop_postgres_12
+stop_postgres_12:
+	docker rm -f postgres-12
 
 .PHONY: start_mysql_57
 start_mysql_57:
@@ -85,3 +94,4 @@ stop_dbs:
 	docker rm -f postgres-9 || true
 	docker rm -f postgres-10 || true
 	docker rm -f postgres-11 || true
+	docker rm -f postgres-12 || true

--- a/ci/blackbox/config.json
+++ b/ci/blackbox/config.json
@@ -190,6 +190,66 @@
                                     "pg_stat_statements"
                                 ]
                             }
+                        },
+                        {
+                            "description": "Micro plan - Postgres 12",
+                            "free": false,
+                            "id": "postgres-micro-12",
+                            "name": "micro-12",
+                            "rds_properties": {
+                                "allocated_storage": 10,
+                                "db_instance_class": "db.t3.micro",
+                                "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
+                                "engine": "postgres",
+                                "engine_version": "12",
+                                "engine_family": "postgres12",
+                                "copy_tags_to_snapshot":true,
+                                "vpc_security_group_ids": [
+                                    "POPULATED_BY_TEST_SUITE"
+                                ],
+                                "default_extensions": [
+                                    "uuid-ossp",
+                                    "postgis",
+                                    "citext"
+                                ],
+                                "allowed_extensions": [
+                                    "uuid-ossp",
+                                    "postgis",
+                                    "citext",
+                                    "pg_stat_statements"
+                                ]
+                            }
+                        },
+                        {
+                            "description": "Micro plan without final snapshot - Postgres 12",
+                            "free": false,
+                            "id": "postgres-micro-without-snapshot-12",
+                            "name": "micro-without-snapshot-12",
+                            "rds_properties": {
+                                "allocated_storage": 10,
+                                "auto_minor_version_upgrade": true,
+                                "db_instance_class": "db.t3.micro",
+                                "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
+                                "engine": "postgres",
+                                "engine_version": "12",
+                                "engine_family": "postgres12",
+                                "skip_final_snapshot": true,
+                                "copy_tags_to_snapshot":true,
+                                "vpc_security_group_ids": [
+                                    "POPULATED_BY_TEST_SUITE"
+                                ],
+                                "default_extensions": [
+                                    "uuid-ossp",
+                                    "postgis",
+                                    "citext"
+                                ],
+                                "allowed_extensions": [
+                                    "uuid-ossp",
+                                    "postgis",
+                                    "citext",
+                                    "pg_stat_statements"
+                                ]
+                            }
                         }
                     ]
                 },

--- a/ci/blackbox/rdsbroker_test.go
+++ b/ci/blackbox/rdsbroker_test.go
@@ -80,7 +80,7 @@ var _ = Describe("RDS Broker Daemon", func() {
 			Expect(service2.Description).To(Equal("AWS RDS PostgreSQL service"))
 			Expect(service2.Bindable).To(BeTrue())
 			Expect(service2.PlanUpdatable).To(BeTrue())
-			Expect(service2.Plans).To(HaveLen(6))
+			Expect(service2.Plans).To(HaveLen(8))
 		})
 	})
 
@@ -224,6 +224,10 @@ var _ = Describe("RDS Broker Daemon", func() {
 			TestProvisionBindDeprovision("postgres", "postgres-micro-without-snapshot-11")
 		})
 
+		Describe("Postgres 12", func() {
+			TestProvisionBindDeprovision("postgres", "postgres-micro-without-snapshot-12")
+		})
+
 		Describe("MySQL 5.7", func() {
 			TestProvisionBindDeprovision("mysql", "mysql-5.7-micro-without-snapshot")
 		})
@@ -288,6 +292,11 @@ var _ = Describe("RDS Broker Daemon", func() {
 		Describe("Postgres 11.5", func() {
 			TestUpdateExtensions("postgres", "postgres-micro-without-snapshot-11")
 		})
+
+		Describe("Postgres 12", func() {
+			TestUpdateExtensions("postgres", "postgres-micro-without-snapshot-12")
+		})
+
 	})
 
 	Describe("update to a plan with a newer engine version", func() {
@@ -531,6 +540,10 @@ var _ = Describe("RDS Broker Daemon", func() {
 			TestFinalSnapshot("postgres", "postgres-micro-11")
 		})
 
+		Describe("Postgres 12", func() {
+			TestFinalSnapshot("postgres", "postgres-micro-12")
+		})
+
 		Describe("MySQL 5.7", func() {
 			TestFinalSnapshot("mysql", "mysql-5.7-micro")
 		})
@@ -656,6 +669,10 @@ var _ = Describe("RDS Broker Daemon", func() {
 
 		Describe("Postgres 11.5", func() {
 			TestRestoreFromSnapshot("postgres", "postgres-micro-11")
+		})
+
+		Describe("Postgres 12", func() {
+			TestRestoreFromSnapshot("postgres", "postgres-micro-12")
 		})
 
 		PDescribe("MySQL 5.7", func() {

--- a/rdsbroker/supported_extensions.go
+++ b/rdsbroker/supported_extensions.go
@@ -9,6 +9,37 @@ type DBExtension struct {
 // that require libraries to be loaded on startup,
 // keyed on database engine family
 var SupportedPreloadExtensions = map[string][]DBExtension{
+	"postgres12": {
+		DBExtension{
+			Name:                   "auto_explain",
+			RequiresPreloadLibrary: true,
+		},
+		DBExtension{
+			Name:                   "orafce",
+			RequiresPreloadLibrary: true,
+		},
+		DBExtension{
+			Name:                   "pgaudit",
+			RequiresPreloadLibrary: true,
+		},
+		DBExtension{
+			Name:                   "pglogical",
+			RequiresPreloadLibrary: true,
+		},
+		DBExtension{
+			Name:                   "pg_similarity",
+			RequiresPreloadLibrary: true,
+		},
+		DBExtension{
+			Name:                   "pg_stat_statements",
+			RequiresPreloadLibrary: true,
+		},
+		DBExtension{
+			Name:                   "pg_hint_plan",
+			RequiresPreloadLibrary: true,
+		},
+	},
+
 	"postgres11": {
 		DBExtension{
 			Name:                   "auto_explain",


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/175721576)

What
===
We want to add Postgres 12.X database engine to our RDS Broker offering.

Why
===
We want to keep up with the versions of Postgres offered by AWS RDS Service.
Our tenants will be upgrading from version 9.5 and version 12.x should be available for them as a default upgrade option (that's the AWS recommendation).

How to review
===
- Code review
- Make sure that the bosh release was built successfully, the PR is [here](https://github.com/alphagov/paas-rds-broker-boshrelease/pull/98)
- Deploy to your dev environment - details are here [paas-cf PR](https://github.com/alphagov/paas-cf/pull/2533)

Who can review
===
Not @barsutka 