### PR TITLE
Tell users how to upgrade from Postgres 9.5

### DIFF
--- a/rdsbroker/broker_update_test.go
+++ b/rdsbroker/broker_update_test.go
@@ -543,7 +543,60 @@ var _ = Describe("RDS Broker", func() {
 					Expect(err).To(Equal(ErrEncryptionNotUpdateable))
 				})
 			})
+		})
 
+		Context("when updating a Postgres 9.5 instance", func() {
+			BeforeEach(func() {
+				rdsProperties1.EngineVersion = stringPointer("9.5.3")
+				rdsProperties1.Engine = stringPointer("postgres")
+				rdsProperties2.Engine = stringPointer("postgres")
+			})
+
+			Context("when going to another Postgres 9.5 plan", func() {
+				BeforeEach(func() {
+					rdsProperties2.EngineVersion = stringPointer("9.5.4")
+				})
+
+				It("succeeds", func() {
+					_, err := rdsBroker.Update(ctx, instanceID, updateDetails, acceptsIncomplete)
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+
+			Context("when going to a Postgres 10 plan", func() {
+				BeforeEach(func() {
+					rdsProperties2.EngineVersion = stringPointer("10")
+				})
+
+				It("succeeds", func() {
+					_, err := rdsBroker.Update(ctx, instanceID, updateDetails, acceptsIncomplete)
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+
+			Context("when going to a Postgres 11 plan", func() {
+				BeforeEach(func() {
+					rdsProperties2.EngineVersion = stringPointer("11")
+				})
+
+				It("returns an error telling the user to upgrade via Postgres 10", func() {
+					_, err := rdsBroker.Update(ctx, instanceID, updateDetails, acceptsIncomplete)
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(Equal(ErrPostgres95UpgradePath))
+				})
+			})
+
+			Context("when going to a Postgres 12 plan", func() {
+				BeforeEach(func() {
+					rdsProperties2.EngineVersion = stringPointer("12")
+				})
+
+				It("returns an error telling the user to upgrade via Postgres 10", func() {
+					_, err := rdsBroker.Update(ctx, instanceID, updateDetails, acceptsIncomplete)
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(Equal(ErrPostgres95UpgradePath))
+				})
+			})
 		})
 
 		Context("when has LicenseModel", func() {


### PR DESCRIPTION
## What

We are about to ask all our users to upgrade from Postgres 9.5, as it is end-of-life early next year.

Unfortunately we don't support a direct upgrade from Postgres 9.5 to our newest version (Postgres 12.) Users must first upgrade from 9.5 to 10, and then direct from 10 to 12.

Until now, a user encountering this limitation has seen an ugly AWS error message that does not help them:

```
Server error, status code: 502, error code: 10001, message: Service broker error: InvalidParameterCombination: RDS does not support creating a DB instance with the following combination: DBInstanceClass=db.t3.micro, Engine=postgres, EngineVersion=9.5.23, LicenseModel=postgresql-license. For supported combinations of instance class and database engine version, see the documentation.
```

With this commit, the user will instead see a more helpful error
explaining what they need to do:

```
Server error, status code: 502, error code: 10001, message: Service broker error: to upgrade from Postgres 9.5, first upgrade to Postgres 10, and then upgrade from there to your desired version
```

This is still not perfect, but users who read this will know exactly what to do. It doesn't replace the need for documentation, but it's a start.

## How to review

* See if the tests pass
* Code review