### PR TITLE
[#176574936] Force Postgis disabled before upgrading

### DIFF
--- a/ci/blackbox/config.json
+++ b/ci/blackbox/config.json
@@ -89,7 +89,6 @@
                                 ],
                                 "default_extensions": [
                                     "uuid-ossp",
-                                    "postgis",
                                     "citext"
                                 ],
                                 "allowed_extensions": [
@@ -120,7 +119,6 @@
                                 ],
                                 "default_extensions": [
                                     "uuid-ossp",
-                                    "postgis",
                                     "citext"
                                 ],
                                 "allowed_extensions": [
@@ -149,7 +147,6 @@
                                 ],
                                 "default_extensions": [
                                     "uuid-ossp",
-                                    "postgis",
                                     "citext"
                                 ],
                                 "allowed_extensions": [
@@ -180,7 +177,6 @@
                                 ],
                                 "default_extensions": [
                                     "uuid-ossp",
-                                    "postgis",
                                     "citext"
                                 ],
                                 "allowed_extensions": [
@@ -209,7 +205,6 @@
                                 ],
                                 "default_extensions": [
                                     "uuid-ossp",
-                                    "postgis",
                                     "citext"
                                 ],
                                 "allowed_extensions": [
@@ -240,7 +235,6 @@
                                 ],
                                 "default_extensions": [
                                     "uuid-ossp",
-                                    "postgis",
                                     "citext"
                                 ],
                                 "allowed_extensions": [

--- a/ci/blackbox/rdsbroker_test.go
+++ b/ci/blackbox/rdsbroker_test.go
@@ -750,11 +750,13 @@ func pollForOperationCompletion(brokerAPIClient *BrokerAPIClient, instanceID, se
 
 	fmt.Fprint(GinkgoWriter, "Polling for Instance Operation to complete")
 	time.Sleep(15 * time.Second) // Ensure the operation has actually started in AWS
+	var lastState string
 	Eventually(
 		func() string {
 			fmt.Fprint(GinkgoWriter, ".")
 			state, err = brokerAPIClient.GetLastOperationState(instanceID, serviceID, planID, operation)
 			Expect(err).ToNot(HaveOccurred())
+			lastState = state
 			return state
 		},
 		INSTANCE_CREATE_TIMEOUT,
@@ -764,6 +766,12 @@ func pollForOperationCompletion(brokerAPIClient *BrokerAPIClient, instanceID, se
 			Equal("succeeded"),
 			Equal("failed"),
 			Equal("gone"),
+		),
+		fmt.Sprintf(
+			"expected instanceID '%s' state to be one of succeeded, failed, gone. It was '%s' after '%d' seconds",
+			instanceID,
+			lastState,
+			INSTANCE_CREATE_TIMEOUT,
 		),
 	)
 

--- a/ci/blackbox/rdsbroker_test.go
+++ b/ci/blackbox/rdsbroker_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	INSTANCE_CREATE_TIMEOUT = 30 * time.Minute
+	INSTANCE_CREATE_TIMEOUT = 45 * time.Minute
 )
 
 var _ = Describe("RDS Broker Daemon", func() {


### PR DESCRIPTION
What
---
The `postgis` extension is causing databases to fail pre-flight checks for Postgres major version upgrades. Failing the checks leads to the upgrade being silently rolled back, from the perspective of the broker.

By forcing `postgis` to be disabled before an upgrade happens, we should be able to avoid it.

How to review
---
Check tests pass
Deploy it in your env
Check you can't upgrade while `postgis` is enabled