### PR TITLE
[#176574936] Disable skipping major Postgres versions

### DIFF
--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -548,22 +548,6 @@ func (b *RDSBroker) Update(
 	}
 	tagsByName := awsrds.RDSTagsValues(tags)
 
-	if aws.StringValue(servicePlan.RDSProperties.Engine) == "postgres" {
-		previousVersion := aws.StringValue(previousServicePlan.RDSProperties.EngineVersion)
-		newVersion := aws.StringValue(servicePlan.RDSProperties.EngineVersion)
-		if strings.HasPrefix(previousVersion, "9.") && !strings.HasPrefix(newVersion, "9.") {
-
-			if postgisIsEnabled(tagsByName) {
-				return brokerapi.UpdateServiceSpec{},
-					apiresponses.NewFailureResponse(
-						fmt.Errorf("Cannot upgrade from postgres 9 when the postgis extension is enabled. Disable the extension, or contact support."),
-						http.StatusBadRequest,
-						"upgrade",
-					)
-			}
-		}
-	}
-
 	if extensionsTag, ok := tagsByName[awsrds.TagExtensions]; ok {
 		if extensionsTag != "" {
 			extensions = mergeExtensions(extensions, strings.Split(extensionsTag, ":"))

--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -40,8 +40,9 @@ const lastOperationResponseLogKey = "lastOperationResponse"
 const extensionsLogKey = "requestedExtensions"
 
 var (
-	ErrEncryptionNotUpdateable            = errors.New("instance can not be updated to a plan with different encryption settings")
-	ErrCannotUpgradePostgres9To11OrHigher = errors.New("cannot upgrade from Postgres 9.5 directly to Postgres 11 or higher. The database must be upgraded to Postgres 10 first")
+	ErrEncryptionNotUpdateable = errors.New("instance can not be updated to a plan with different encryption settings")
+	ErrCannotSkipMajorVersion  = errors.New("cannot skip major Postgres versions. Please upgrade one major version at a time (e.g. 10, to 11, to 12)")
+	ErrCannotDowngrade         = errors.New("cannot downgrade major versions")
 )
 
 var rdsStatus2State = map[string]brokerapi.LastOperationState{
@@ -477,11 +478,30 @@ func (b *RDSBroker) Update(
 		return brokerapi.UpdateServiceSpec{}, err
 	}
 
-	previousPlanIs9x := strings.HasPrefix(*previousServicePlan.RDSProperties.EngineVersion, "9.")
-	newPlanIs11OrNewer := !strings.HasPrefix(*servicePlan.RDSProperties.EngineVersion, "9.") && !strings.HasPrefix(*servicePlan.RDSProperties.EngineVersion, "10")
+	oldVersion, err := previousServicePlan.EngineVersion()
+	if err != nil {
+		return brokerapi.UpdateServiceSpec{}, err
+	}
+	newVersion, err := servicePlan.EngineVersion()
+	if err != nil {
+		return brokerapi.UpdateServiceSpec{}, err
+	}
+
+	if newVersion.Major() < oldVersion.Major() {
+		err := ErrCannotDowngrade
+		b.logger.Error("downgrade-attempted", err)
+		return brokerapi.UpdateServiceSpec{},
+			apiresponses.NewFailureResponse(
+				err,
+				http.StatusBadRequest,
+				"upgrade",
+			)
+	}
+
 	if aws.StringValue(servicePlan.RDSProperties.Engine) == "postgres" {
-		if previousPlanIs9x && newPlanIs11OrNewer {
-			err := ErrCannotUpgradePostgres9To11OrHigher
+		majorVersionDifference := newVersion.Major() - oldVersion.Major()
+		if majorVersionDifference > 1 {
+			err := ErrCannotSkipMajorVersion
 			b.logger.Error("invalid-upgrade-path", err)
 			return brokerapi.UpdateServiceSpec{},
 				apiresponses.NewFailureResponse(

--- a/rdsbroker/broker_update_test.go
+++ b/rdsbroker/broker_update_test.go
@@ -34,12 +34,14 @@ var _ = Describe("RDS Broker", func() {
 		rdsPropertiesPSQL9  RDSProperties
 		rdsPropertiesPSQL10 RDSProperties
 		rdsPropertiesPSQL11 RDSProperties
+		rdsPropertiesPSQL12 RDSProperties
 		plan1               ServicePlan
 		plan2               ServicePlan
 		plan3               ServicePlan
 		planPSQL9           ServicePlan
 		planPSQL10          ServicePlan
 		planPSQL11          ServicePlan
+		planPSQL12          ServicePlan
 		service1            Service
 		service2            Service
 		service3            Service
@@ -158,7 +160,6 @@ var _ = Describe("RDS Broker", func() {
 			AllocatedStorage:  int64Pointer(200),
 			SkipFinalSnapshot: boolPointer(skipFinalSnapshot),
 			DefaultExtensions: []*string{
-				stringPointer("postgis"),
 				stringPointer("pg_stat_statements"),
 			},
 			AllowedExtensions: []*string{
@@ -174,7 +175,6 @@ var _ = Describe("RDS Broker", func() {
 			AllocatedStorage:  int64Pointer(200),
 			SkipFinalSnapshot: boolPointer(skipFinalSnapshot),
 			DefaultExtensions: []*string{
-				stringPointer("postgis"),
 				stringPointer("pg_stat_statements"),
 			},
 			AllowedExtensions: []*string{
@@ -190,7 +190,21 @@ var _ = Describe("RDS Broker", func() {
 			AllocatedStorage:  int64Pointer(200),
 			SkipFinalSnapshot: boolPointer(skipFinalSnapshot),
 			DefaultExtensions: []*string{
+				stringPointer("pg_stat_statements"),
+			},
+			AllowedExtensions: []*string{
 				stringPointer("postgis"),
+				stringPointer("pg_stat_statements"),
+				stringPointer("postgres_super_extension"),
+			},
+		}
+		rdsPropertiesPSQL12 = RDSProperties{
+			DBInstanceClass:   stringPointer("db.t3.small"),
+			Engine:            stringPointer("postgres"),
+			EngineVersion:     stringPointer("12"),
+			AllocatedStorage:  int64Pointer(200),
+			SkipFinalSnapshot: boolPointer(skipFinalSnapshot),
+			DefaultExtensions: []*string{
 				stringPointer("pg_stat_statements"),
 			},
 			AllowedExtensions: []*string{
@@ -244,6 +258,14 @@ var _ = Describe("RDS Broker", func() {
 			Metadata:      nil,
 			RDSProperties: rdsPropertiesPSQL11,
 		}
+		planPSQL12 = ServicePlan{
+			ID:            "plan-psql12",
+			Name:          "Plan PSQL 12",
+			Description:   "",
+			Free:          nil,
+			Metadata:      nil,
+			RDSProperties: rdsPropertiesPSQL12,
+		}
 
 		service1 = Service{
 			ID:            "Service-1",
@@ -275,6 +297,7 @@ var _ = Describe("RDS Broker", func() {
 				planPSQL9,
 				planPSQL10,
 				planPSQL11,
+				planPSQL12,
 			},
 		}
 
@@ -998,9 +1021,39 @@ var _ = Describe("RDS Broker", func() {
 				Expect(aws.StringValue(input.EngineVersion)).To(Equal("4.5.6"))
 				Expect(aws.StringValue(input.DBParameterGroupName)).To(Equal(newParamGroupName))
 			})
+
+			It("cannot be downgraded", func() {
+				updateDetails.PlanID = planPSQL10.ID
+				updateDetails.ServiceID = servicePSQL.ID
+				updateDetails.PreviousValues = domain.PreviousValues{
+					PlanID:    planPSQL12.ID,
+					ServiceID: servicePSQL.ID,
+					OrgID:     updateDetails.PreviousValues.OrgID,
+					SpaceID:   updateDetails.PreviousValues.SpaceID,
+				}
+
+				_, err := rdsBroker.Update(ctx, instanceID, updateDetails, acceptsIncomplete)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal(ErrCannotDowngrade.Error()))
+			})
+
+			It("cannot be changed by more than 1 major version", func() {
+				updateDetails.PlanID = planPSQL12.ID
+				updateDetails.ServiceID = servicePSQL.ID
+				updateDetails.PreviousValues = domain.PreviousValues{
+					PlanID:    planPSQL10.ID,
+					ServiceID: servicePSQL.ID,
+					OrgID:     updateDetails.PreviousValues.OrgID,
+					SpaceID:   updateDetails.PreviousValues.SpaceID,
+				}
+
+				_, err := rdsBroker.Update(ctx, instanceID, updateDetails, acceptsIncomplete)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal(ErrCannotSkipMajorVersion.Error()))
+			})
 		})
 
-		Context("if an extension is in both enable_extensions and disable_enxtension", func() {
+		Context("if an extension is in both enable_extensions and disable_extension", func() {
 			It("returns an error", func() {
 				updateDetails.RawParameters = json.RawMessage(`{"disable_extensions": ["postgres_super_extension"], "enable_extensions": ["postgres_super_extension"]}`)
 				_, err := rdsBroker.Update(ctx, instanceID, updateDetails, acceptsIncomplete)
@@ -1227,22 +1280,6 @@ var _ = Describe("RDS Broker", func() {
 
 				_, err := rdsBroker.Update(ctx, instanceID, updateDetails, acceptsIncomplete)
 				Expect(err).ToNot(HaveOccurred())
-			})
-
-			It("it must be upgraded to postgres 10", func() {
-				updateDetails.PlanID = planPSQL11.ID
-				updateDetails.ServiceID = servicePSQL.ID
-				updateDetails.PreviousValues = domain.PreviousValues{
-					PlanID:    planPSQL9.ID,
-					ServiceID: servicePSQL.ID,
-					OrgID:     updateDetails.PreviousValues.OrgID,
-					SpaceID:   updateDetails.PreviousValues.SpaceID,
-				}
-
-				_, err := rdsBroker.Update(ctx, instanceID, updateDetails, acceptsIncomplete)
-				Expect(err).To(BeAssignableToTypeOf(&brokerapi.FailureResponse{}))
-				failureResponse := err.(*brokerapi.FailureResponse)
-				Expect(failureResponse.Error()).To(Equal(ErrCannotUpgradePostgres9To11OrHigher.Error()))
 			})
 		})
 

--- a/rdsbroker/broker_update_test.go
+++ b/rdsbroker/broker_update_test.go
@@ -1243,46 +1243,6 @@ var _ = Describe("RDS Broker", func() {
 			})
 		})
 
-		Context("when the postgres version is being changed away from 9", func() {
-			BeforeEach(func() {
-				updateDetails.PlanID = planPSQL10.ID
-				updateDetails.ServiceID = servicePSQL.ID
-				updateDetails.PreviousValues = domain.PreviousValues{
-					PlanID:    planPSQL9.ID,
-					ServiceID: servicePSQL.ID,
-					OrgID:     updateDetails.PreviousValues.OrgID,
-					SpaceID:   updateDetails.PreviousValues.SpaceID,
-				}
-
-				rdsInstance.GetResourceTagsCalls(func(resourceArn string, opts ...awsrds.DescribeOption) ([]*rds.Tag, error) {
-					if resourceArn == "arn:aws:rds::i-have-postgis-enabled" {
-						return []*rds.Tag{
-							&rds.Tag{
-								Key:   aws.String("Extensions"),
-								Value: aws.String("postgis:someother"),
-							},
-						}, nil
-					}
-
-					return []*rds.Tag{}, nil
-				})
-			})
-
-			It("when the postgis extension is enabled, returns an error", func() {
-				existingDbInstance.DBInstanceArn = aws.String("arn:aws:rds::i-have-postgis-enabled")
-
-				_, err := rdsBroker.Update(ctx, instanceID, updateDetails, acceptsIncomplete)
-				Expect(err).To(MatchError("Cannot upgrade from postgres 9 when the postgis extension is enabled. Disable the extension, or contact support."))
-			})
-
-			It("when the postgis extension is not enabled, does not return an error", func() {
-				existingDbInstance.DBInstanceArn = aws.String("arn:aws:rds::i-do-not-have-postgis-enabled")
-
-				_, err := rdsBroker.Update(ctx, instanceID, updateDetails, acceptsIncomplete)
-				Expect(err).ToNot(HaveOccurred())
-			})
-		})
-
 		Context("when the postgres version is being changed from 9 to 9", func() {
 			BeforeEach(func() {
 				rdsProperties1.Engine = aws.String("postgres")

--- a/rdsbroker/catalog.go
+++ b/rdsbroker/catalog.go
@@ -160,20 +160,26 @@ func (sp ServicePlan) IsUpgradeFrom(oldPlan ServicePlan) (bool, error) {
 		)
 	}
 
-	oldPlanVersionStr := *oldPlan.RDSProperties.EngineVersion
-	newPlanVersionStr := *sp.RDSProperties.EngineVersion
-
-	oldPlanSemVer, err := semver.NewVersion(oldPlanVersionStr)
+	oldPlanSemVer, err := oldPlan.EngineVersion()
 	if err != nil {
-		return false, fmt.Errorf("old engine version must be a semantic version number: '%s'", oldPlanVersionStr)
+		return false, err
 	}
 
-	newPlanSemVer, err := semver.NewVersion(newPlanVersionStr)
+	newPlanSemVer, err := sp.EngineVersion()
 	if err != nil {
-		return false, fmt.Errorf("new engine version must be a semantic version number: '%s'", newPlanVersionStr)
+		return false, err
 	}
 
 	return newPlanSemVer.GreaterThan(oldPlanSemVer), nil
+}
+
+func (sp ServicePlan) EngineVersion() (*semver.Version, error) {
+	ver, err := semver.NewVersion(*sp.RDSProperties.EngineVersion)
+	if err != nil {
+		return nil, fmt.Errorf("engine version must be a semantic version number: '%s'", ver)
+	}
+
+	return ver, nil
 }
 
 func (rp RDSProperties) Validate(c Catalog) error {


### PR DESCRIPTION
What
---
This PR does two things:
1. Prevents Postgres upgrades from skipping a major version. [This is an AWS RDS limitation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.PostgreSQL.html#USER_UpgradeDBInstance.PostgreSQL.MajorVersion)

2. Relaxes the restriction on the postgis extension being disabled before an upgrade

How to review
---
1. Code review
2. Deploy and test