### PR TITLE
Set MySQL max packet to 256mb

### DIFF
--- a/ci/blackbox/config.json
+++ b/ci/blackbox/config.json
@@ -18,60 +18,6 @@
                     "plan_updateable": true,
                     "plans": [
                         {
-                            "description": "Micro plan",
-                            "free": false,
-                            "id": "postgres-micro",
-                            "name": "micro",
-                            "rds_properties": {
-                                "allocated_storage": 10,
-                                "db_instance_class": "db.t2.micro",
-                                "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
-                                "engine": "postgres",
-                                "engine_version": "9.5",
-                                "engine_family": "postgres9.5",
-                                "copy_tags_to_snapshot":true,
-                                "vpc_security_group_ids": [
-                                    "POPULATED_BY_TEST_SUITE"
-                                ],
-                                "default_extensions": [
-                                    "uuid-ossp"
-                                ],
-                                "allowed_extensions": [
-                                    "uuid-ossp",
-                                    "postgis",
-                                    "pg_stat_statements"
-                                ]
-                            }
-                        },
-                        {
-                            "description": "Micro plan without final snapshot",
-                            "free": false,
-                            "id": "postgres-micro-without-snapshot",
-                            "name": "micro-without-snapshot",
-                            "rds_properties": {
-                                "allocated_storage": 10,
-                                "auto_minor_version_upgrade": true,
-                                "db_instance_class": "db.t2.micro",
-                                "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
-                                "engine": "postgres",
-                                "engine_version": "9.5",
-                                "engine_family": "postgres9.5",
-                                "skip_final_snapshot": true,
-                                "copy_tags_to_snapshot":true,
-                                "vpc_security_group_ids": [
-                                    "POPULATED_BY_TEST_SUITE"
-                                ],
-                                "default_extensions": [
-                                    "uuid-ossp"
-                                ],
-                                "allowed_extensions": [
-                                    "uuid-ossp",
-                                    "postgis",
-                                    "pg_stat_statements"
-                                ]
-                            }
-                        },
-                        {
                             "description": "Micro plan - Postgres 10",
                             "free": false,
                             "id": "postgres-micro-10",

--- a/ci/blackbox/rdsbroker_test.go
+++ b/ci/blackbox/rdsbroker_test.go
@@ -80,7 +80,7 @@ var _ = Describe("RDS Broker Daemon", func() {
 			Expect(service2.Description).To(Equal("AWS RDS PostgreSQL service"))
 			Expect(service2.Bindable).To(BeTrue())
 			Expect(service2.PlanUpdatable).To(BeTrue())
-			Expect(service2.Plans).To(HaveLen(8))
+			Expect(service2.Plans).To(HaveLen(6))
 		})
 	})
 
@@ -212,10 +212,6 @@ var _ = Describe("RDS Broker Daemon", func() {
 			})
 		}
 
-		Describe("Postgres 9.5", func() {
-			TestProvisionBindDeprovision("postgres", "postgres-micro-without-snapshot")
-		})
-
 		Describe("Postgres 10.5", func() {
 			TestProvisionBindDeprovision("postgres", "postgres-micro-without-snapshot-10")
 		})
@@ -281,10 +277,6 @@ var _ = Describe("RDS Broker Daemon", func() {
 			})
 		}
 
-		Describe("Postgres 9.5", func() {
-			TestUpdateExtensions("postgres", "postgres-micro-without-snapshot")
-		})
-
 		Describe("Postgres 10.5", func() {
 			TestUpdateExtensions("postgres", "postgres-micro-without-snapshot-10")
 		})
@@ -334,41 +326,6 @@ var _ = Describe("RDS Broker Daemon", func() {
 				Expect(extensions).To(Equal("succeeded"))
 			})
 		}
-
-		Describe("Postgres 9.5 to 10", func() {
-			TestUpdatePlan("postgres", "postgres-micro-without-snapshot", "postgres-micro-without-snapshot-10")
-		})
-
-		Describe("Postgres 9.5 to 11 or higher", func() {
-			var (
-				instanceID string
-				serviceID  = "postgres"
-				startPlan  = "postgres-micro"
-				endPlan    = "postgres-micro-11"
-			)
-
-			BeforeEach(func() {
-				instanceID = uuid.NewV4().String()
-
-				brokerAPIClient.AcceptsIncomplete = true
-
-				params := `{
-						"enable_extensions": []
-					}`
-
-				code, operation, err := brokerAPIClient.ProvisionInstance(instanceID, serviceID, startPlan, params)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(code).To(Equal(202))
-				state := pollForOperationCompletion(brokerAPIClient, instanceID, serviceID, startPlan, operation)
-				Expect(state).To(Equal("succeeded"))
-			})
-
-			It("cannot be upgraded", func() {
-				code, _, err := brokerAPIClient.UpdateInstance(instanceID, serviceID, startPlan, endPlan, `{}`)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(code).To(Equal(400))
-			})
-		})
 
 		Describe("Postgres 10 to 11", func() {
 			TestUpdatePlan("postgres", "postgres-micro-without-snapshot-10", "postgres-micro-without-snapshot-11")
@@ -477,10 +434,6 @@ var _ = Describe("RDS Broker Daemon", func() {
 				Expect(err).To(HaveOccurred())
 			})
 		}
-
-		Describe("Postgres 9.5", func() {
-			TestFinalSnapshot("postgres", "postgres-micro")
-		})
 
 		Describe("Postgres 10.5", func() {
 			TestFinalSnapshot("postgres", "postgres-micro-10")
@@ -608,10 +561,6 @@ var _ = Describe("RDS Broker Daemon", func() {
 				secondInstance.Wait()
 			})
 		}
-
-		Describe("Postgres 9.5", func() {
-			TestRestoreFromSnapshot("postgres", "postgres-micro")
-		})
 
 		Describe("Postgres 10.5", func() {
 			TestRestoreFromSnapshot("postgres", "postgres-micro-10")

--- a/rdsbroker/parameter_groups_source_test.go
+++ b/rdsbroker/parameter_groups_source_test.go
@@ -2,6 +2,7 @@ package rdsbroker
 
 import (
 	"errors"
+	"strconv"
 
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagertest"
@@ -226,18 +227,6 @@ var _ = Describe("ParameterGroupsSource", func() {
 
 			Describe("when it is for a Postgres database", func() {
 				Describe("it modifies the created parameter group", func() {
-					It("does not make any changes to the parameter group for MySQL databases", func() {
-						servicePlan.RDSProperties.Engine = aws.String("mysql")
-						servicePlan.RDSProperties.EngineVersion = aws.String("5.7")
-						servicePlan.RDSProperties.EngineFamily = aws.String("mysql5.7")
-
-						rdsFake.ModifyParameterGroupReturns(nil)
-
-						parameterGroupSource.SelectParameterGroup(servicePlan, extensions)
-
-						Expect(rdsFake.ModifyParameterGroupCallCount()).To(Equal(0), "ModifyParameterGroup was called when it shouldn't have been")
-					})
-
 					It("and sets the force SSL property", func() {
 						rdsFake.ModifyParameterGroupReturns(nil)
 
@@ -327,9 +316,32 @@ var _ = Describe("ParameterGroupsSource", func() {
 
 					Expect(discovered).To(BeFalse(), "The shared_preload_libraries property was set when it shouldn't have been")
 				})
-
 			})
 
+			Describe("when it is for a MySQL database", func() {
+				BeforeEach(func() {
+					servicePlan.RDSProperties.Engine = aws.String("mysql")
+				})
+
+				It("will set the 'max_allowed_packet' property to 256mb", func() {
+					rdsFake.ModifyParameterGroupReturns(nil)
+
+					parameterGroupSource.SelectParameterGroup(servicePlan, extensions)
+					Expect(rdsFake.ModifyParameterGroupCallCount()).To(Equal(1), "ModifyParameterGroup was not called")
+
+					modifyInput := rdsFake.ModifyParameterGroupArgsForCall(0)
+
+					var relevantParam *rds.Parameter = nil
+					for _, param := range modifyInput.Parameters {
+						if aws.StringValue(param.ParameterName) == "max_allowed_packet" {
+							relevantParam = param
+						}
+					}
+
+					Expect(relevantParam).ToNot(BeNil())
+					Expect(aws.StringValue(relevantParam.ParameterValue)).To(Equal(strconv.Itoa(1024 * 1024 * 256)))
+				})
+			})
 		})
 
 	})


### PR DESCRIPTION
What
---
`max_allowed_packet` defaults to 4mb, but Amazon's recommended value [1] is 64mb. This causes issues for MySQL users who are using BLOB type columns, or otherwise have large field values.

We've raised this to 256mb, after a [support request](https://govuk.zendesk.com/agent/tickets/4476087)

The value has been set by hand for existing parameter groups
    
[1] https://aws.amazon.com/blogs/database/best-practices-for-configuring-parameters-for-amazon-rds-for-mysql-part-3-parameters-related-to-security-operational-manageability-and-connectivity-timeout/

How to review
---
1. Code review