### PR TITLE
Exclude temp tables from read-only access trigger

### DIFF
--- a/sqlengine/postgres_engine.go
+++ b/sqlengine/postgres_engine.go
@@ -501,8 +501,10 @@ const ensurePermissionsTriggersPattern = `
 	create or replace function make_readable_generic() returns void language plpgsql set search_path to public as {{.makeReadableGenericBodyStr}};
 	create or replace function make_readable() returns event_trigger language plpgsql set search_path to public as $$
 	begin
-		EXECUTE 'select make_readable_generic()';
-		RETURN;
+		IF EXISTS (SELECT 1 FROM pg_event_trigger_ddl_commands() WHERE schema_name NOT LIKE 'pg_temp%') THEN
+			EXECUTE 'select make_readable_generic()';
+			RETURN;
+		END IF;
 	end
 	$$;
 	create or replace function forbid_ddl_reader() returns event_trigger language plpgsql set search_path to public as {{.forbidDDLReaderBodyStr}};


### PR DESCRIPTION
What
---

The trigger make_readable is executed on a number of CREATE commands and grants SELECT on all tables and sequences as well as USAGE on all schemata.
If a table is created within a stored procedure, this trigger does not return and keeps an AccessExlusiveLock on all tables. This is effectively globally locking the entire database for the runtime of the stored procedure, which may be substantial (The billing update_resources function runs for 2h+ in London).

This modification evaluates the schema_name of the pg_event_trigger_ddl_commands() to prevent the trigger from being
executed if a temporary table is created. As we are using temporary tables in the stored procedures this will prevent locking the database for their runtime.

We do not envision this change to impact the read-only functionality for tenants and read-only users should not need to access temporary tables - TBD.

pair: @whpearson @schmie

How to review
---

- Code review 
- Change is deployed to dev env `schmie`: connect to a postgres db via conduit and see that `create temporary table test_1 (idx int);` does not output the chatter of the trigger, i.e. `WARNING:  no privileges were granted for "sql_packages"` etc.