### PR TITLE
fix restore for postgres 13

### DIFF
--- a/ci/blackbox/config.json
+++ b/ci/blackbox/config.json
@@ -196,6 +196,66 @@
                                     "pg_stat_statements"
                                 ]
                             }
+                        },
+                        {
+                            "description": "Micro plan - Postgres 13",
+                            "free": false,
+                            "id": "postgres-micro-13",
+                            "name": "micro-13",
+                            "rds_properties": {
+                                "allocated_storage": 10,
+                                "db_instance_class": "db.t3.micro",
+                                "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
+                                "engine": "postgres",
+                                "engine_version": "13",
+                                "engine_family": "postgres13",
+                                "copy_tags_to_snapshot":true,
+                                "vpc_security_group_ids": [
+                                    "POPULATED_BY_TEST_SUITE"
+                                ],
+                                "default_extensions": [
+                                    "uuid-ossp",
+                                    "postgis",
+                                    "citext"
+                                ],
+                                "allowed_extensions": [
+                                    "uuid-ossp",
+                                    "postgis",
+                                    "citext",
+                                    "pg_stat_statements"
+                                ]
+                            }
+                        },
+                        {
+                            "description": "Micro plan without final snapshot - Postgres 13",
+                            "free": false,
+                            "id": "postgres-micro-without-snapshot-13",
+                            "name": "micro-without-snapshot-13",
+                            "rds_properties": {
+                                "allocated_storage": 10,
+                                "auto_minor_version_upgrade": true,
+                                "db_instance_class": "db.t3.micro",
+                                "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
+                                "engine": "postgres",
+                                "engine_version": "13",
+                                "engine_family": "postgres13",
+                                "skip_final_snapshot": true,
+                                "copy_tags_to_snapshot":true,
+                                "vpc_security_group_ids": [
+                                    "POPULATED_BY_TEST_SUITE"
+                                ],
+                                "default_extensions": [
+                                    "uuid-ossp",
+                                    "postgis",
+                                    "citext"
+                                ],
+                                "allowed_extensions": [
+                                    "uuid-ossp",
+                                    "postgis",
+                                    "citext",
+                                    "pg_stat_statements"
+                                ]
+                            }
                         }
                     ]
                 },

--- a/ci/blackbox/rdsbroker_test.go
+++ b/ci/blackbox/rdsbroker_test.go
@@ -80,7 +80,7 @@ var _ = Describe("RDS Broker Daemon", func() {
 			Expect(service2.Description).To(Equal("AWS RDS PostgreSQL service"))
 			Expect(service2.Bindable).To(BeTrue())
 			Expect(service2.PlanUpdatable).To(BeTrue())
-			Expect(service2.Plans).To(HaveLen(6))
+			Expect(service2.Plans).To(HaveLen(8))
 		})
 	})
 
@@ -212,16 +212,12 @@ var _ = Describe("RDS Broker Daemon", func() {
 			})
 		}
 
-		Describe("Postgres 10.5", func() {
+		Describe("Postgres 10", func() {
 			TestProvisionBindDeprovision("postgres", "postgres-micro-without-snapshot-10")
 		})
 
-		Describe("Postgres 11.5", func() {
-			TestProvisionBindDeprovision("postgres", "postgres-micro-without-snapshot-11")
-		})
-
-		Describe("Postgres 12", func() {
-			TestProvisionBindDeprovision("postgres", "postgres-micro-without-snapshot-12")
+		Describe("Postgres 13", func() {
+			TestProvisionBindDeprovision("postgres", "postgres-micro-without-snapshot-13")
 		})
 
 		Describe("MySQL 5.7", func() {
@@ -277,16 +273,12 @@ var _ = Describe("RDS Broker Daemon", func() {
 			})
 		}
 
-		Describe("Postgres 10.5", func() {
+		Describe("Postgres 10", func() {
 			TestUpdateExtensions("postgres", "postgres-micro-without-snapshot-10")
 		})
 
-		Describe("Postgres 11.5", func() {
-			TestUpdateExtensions("postgres", "postgres-micro-without-snapshot-11")
-		})
-
-		Describe("Postgres 12", func() {
-			TestUpdateExtensions("postgres", "postgres-micro-without-snapshot-12")
+		Describe("Postgres 13", func() {
+			TestUpdateExtensions("postgres", "postgres-micro-without-snapshot-13")
 		})
 
 	})
@@ -333,6 +325,10 @@ var _ = Describe("RDS Broker Daemon", func() {
 
 		Describe("Postgres 11 to 12", func() {
 			TestUpdatePlan("postgres", "postgres-micro-without-snapshot-11", "postgres-micro-without-snapshot-12")
+		})
+
+		Describe("Postgres 12 to 13", func() {
+			TestUpdatePlan("postgres", "postgres-micro-without-snapshot-12", "postgres-micro-without-snapshot-13")
 		})
 
 		Describe("MySQL 5.7 to 8.0", func() {
@@ -435,16 +431,12 @@ var _ = Describe("RDS Broker Daemon", func() {
 			})
 		}
 
-		Describe("Postgres 10.5", func() {
+		Describe("Postgres 10", func() {
 			TestFinalSnapshot("postgres", "postgres-micro-10")
 		})
 
-		Describe("Postgres 11.5", func() {
-			TestFinalSnapshot("postgres", "postgres-micro-11")
-		})
-
-		Describe("Postgres 12", func() {
-			TestFinalSnapshot("postgres", "postgres-micro-12")
+		Describe("Postgres 13", func() {
+			TestFinalSnapshot("postgres", "postgres-micro-13")
 		})
 
 		Describe("MySQL 5.7", func() {
@@ -683,16 +675,12 @@ var _ = Describe("RDS Broker Daemon", func() {
 			})
 		}
 
-		Describe("Postgres 10.5", func() {
+		Describe("Postgres 10", func() {
 			TestRestoreFromSnapshot("postgres", "postgres-micro-10")
 		})
 
-		Describe("Postgres 11.5", func() {
-			TestRestoreFromSnapshot("postgres", "postgres-micro-11")
-		})
-
-		Describe("Postgres 12", func() {
-			TestRestoreFromSnapshot("postgres", "postgres-micro-12")
+		Describe("Postgres 13", func() {
+			TestRestoreFromSnapshot("postgres", "postgres-micro-13")
 		})
 
 		Describe("MySQL 5.7", func() {
@@ -814,8 +802,12 @@ var _ = Describe("RDS Broker Daemon", func() {
 			})
 		}
 
-		Describe("Postgres 12", func() {
-			TestRestoreFromPointInTime("postgres", "postgres-micro-12")
+		Describe("Postgres 10", func() {
+			TestRestoreFromPointInTime("postgres", "postgres-micro-10")
+		})
+
+		Describe("Postgres 13", func() {
+			TestRestoreFromPointInTime("postgres", "postgres-micro-13")
 		})
 
 		Describe("MySQL 5.7", func() {

--- a/sqlengine/postgres_engine.go
+++ b/sqlengine/postgres_engine.go
@@ -284,8 +284,13 @@ func (d *PostgresEngine) ResetState() error {
 func (d *PostgresEngine) listNonSuperUsers(logger lager.Logger) ([]string, error) {
 	users := []string{}
 
+	// rdstopmgr is a monitoring user role introduced by AWS in RDS PostgreSQL 13
 	rows, err := d.db.Query(
-		"select usename from pg_user where usesuper != true and usename != current_user",
+		`select usename
+		from pg_user
+		where usesuper != true
+		and usename != current_user
+		and usename != 'rdstopmgr'`,
 	)
 	if err != nil {
 		logger.Error("sql-error", err)


### PR DESCRIPTION
This PR was originally just to add test coverage for postgres 13:

> Still trying to limit the number of tests as they are very slow, make sure we at least test the versions of postgres at the limits of our support - the oldest (currently 10) and the newest (currently 13).

> This does mean that 11 and 12 technically will get less coverage.