### PR TITLE
Better handling of plan change failures

### DIFF
--- a/awsrds/db_instance.go
+++ b/awsrds/db_instance.go
@@ -45,6 +45,47 @@ func (ct ByCreateTime) Less(i, j int) bool {
 	return aws.TimeValue(ct[i].SnapshotCreateTime).After(aws.TimeValue(ct[j].SnapshotCreateTime))
 }
 
+type awsRdsErr struct {
+	orig error
+	code string
+}
+
+func (a awsRdsErr) Error() string {
+	return a.orig.Error()
+}
+
+func (a awsRdsErr) Code() string {
+	return a.code
+}
+
+func (a awsRdsErr) OrigErr() error {
+	return a.orig
+}
+
+func NewError(err error, code string) Error {
+	return &awsRdsErr{
+		orig: err,
+		code: code,
+	}
+}
+
+type Error interface {
+	// Satisfy the generic error interface.
+	error
+
+	// Returns the short phrase depicting the classification of the error.
+	Code() string
+
+	// Returns the original error if one was set.  Nil is returned if not set.
+	OrigErr() error
+}
+
 var (
-	ErrDBInstanceDoesNotExist = errors.New("rds db instance does not exist")
+	ErrCodeDBInstanceDoesNotExist = "DBInstanceDoesNotExist"
+	ErrCodeInvalidParameterCombination = "InvalidParameterCombination"
+
+	ErrDBInstanceDoesNotExist = NewError(
+		errors.New("rds db instance does not exist"),
+		ErrCodeDBInstanceDoesNotExist,
+	)
 )

--- a/awsrds/rds_db_instance_test.go
+++ b/awsrds/rds_db_instance_test.go
@@ -1129,7 +1129,7 @@ var _ = Describe("RDS DB Instance", func() {
 					input := r.Params.(*rds.ListTagsForResourceInput)
 					Expect(aws.StringValue(input.ResourceName)).To(Equal(listTagsARNs[listTagsCnt]))
 					data := r.Data.(*rds.ListTagsForResourceOutput)
-					data.TagList = BuilRDSTags(listTags[listTagsCnt])
+					data.TagList = BuildRDSTags(listTags[listTagsCnt])
 					if len(listTagsForResourceError) > listTagsCnt {
 						r.Error = listTagsForResourceError[listTagsCnt]
 					}

--- a/awsrds/utils.go
+++ b/awsrds/utils.go
@@ -70,7 +70,13 @@ func HandleAWSError(err error, logger lager.Logger) error {
 		if awsErr.Code() == rds.ErrCodeDBInstanceNotFoundFault {
 			return ErrDBInstanceDoesNotExist
 		}
-		return errors.New(awsErr.Code() + ": " + awsErr.Message())
+		if awsErr.Code() == "InvalidParameterCombination" {
+			return NewError(
+				errors.New(awsErr.Code() + ": " + awsErr.Message()),
+				ErrCodeInvalidParameterCombination,
+			)
+		}
+		return NewError(errors.New(awsErr.Code() + ": " + awsErr.Message()), "")
 	}
 	return err
 }

--- a/awsrds/utils.go
+++ b/awsrds/utils.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/rds"
 )
 
-func BuilRDSTags(tags map[string]string) []*rds.Tag {
+func BuildRDSTags(tags map[string]string) []*rds.Tag {
 	var rdsTags []*rds.Tag
 
 	for key, value := range tags {

--- a/awsrds/utils_test.go
+++ b/awsrds/utils_test.go
@@ -38,7 +38,7 @@ var _ = Describe("RDS Utils", func() {
 		logger.RegisterSink(testSink)
 	})
 
-	var _ = Describe("BuilRDSTags", func() {
+	var _ = Describe("BuildRDSTags", func() {
 		var (
 			tags          map[string]string
 			properRDSTags []*rds.Tag
@@ -55,7 +55,7 @@ var _ = Describe("RDS Utils", func() {
 		})
 
 		It("returns the proper RDS Tags", func() {
-			rdsTags := BuilRDSTags(tags)
+			rdsTags := BuildRDSTags(tags)
 			Expect(rdsTags).To(Equal(properRDSTags))
 		})
 	})

--- a/ci/blackbox/config.json
+++ b/ci/blackbox/config.json
@@ -29,6 +29,7 @@
                                 "engine": "postgres",
                                 "engine_version": "10",
                                 "engine_family": "postgres10",
+                                "multi_az": false,
                                 "copy_tags_to_snapshot":true,
                                 "vpc_security_group_ids": [
                                     "POPULATED_BY_TEST_SUITE"
@@ -40,6 +41,7 @@
                                 ],
                                 "allowed_extensions": [
                                     "uuid-ossp",
+                                    "tsearch2",
                                     "postgis",
                                     "citext",
                                     "pg_stat_statements"
@@ -59,6 +61,7 @@
                                 "engine": "postgres",
                                 "engine_version": "10",
                                 "engine_family": "postgres10",
+                                "multi_az": false,
                                 "skip_final_snapshot": true,
                                 "copy_tags_to_snapshot":true,
                                 "vpc_security_group_ids": [
@@ -71,6 +74,7 @@
                                 ],
                                 "allowed_extensions": [
                                     "uuid-ossp",
+                                    "tsearch2",
                                     "postgis",
                                     "citext",
                                     "pg_stat_statements"
@@ -89,6 +93,7 @@
                                 "engine": "postgres",
                                 "engine_version": "11",
                                 "engine_family": "postgres11",
+                                "multi_az": false,
                                 "copy_tags_to_snapshot":true,
                                 "vpc_security_group_ids": [
                                     "POPULATED_BY_TEST_SUITE"
@@ -119,6 +124,39 @@
                                 "engine": "postgres",
                                 "engine_version": "11",
                                 "engine_family": "postgres11",
+                                "multi_az": false,
+                                "skip_final_snapshot": true,
+                                "copy_tags_to_snapshot":true,
+                                "vpc_security_group_ids": [
+                                    "POPULATED_BY_TEST_SUITE"
+                                ],
+                                "default_extensions": [
+                                    "uuid-ossp",
+                                    "postgis",
+                                    "citext"
+                                ],
+                                "allowed_extensions": [
+                                    "uuid-ossp",
+                                    "postgis",
+                                    "citext",
+                                    "pg_stat_statements"
+                                ]
+                            }
+                        },
+                        {
+                            "description": "Small plan without final snapshot - Postgres 11",
+                            "free": false,
+                            "id": "postgres-small-without-snapshot-11",
+                            "name": "small-without-snapshot-11",
+                            "rds_properties": {
+                                "allocated_storage": 15,
+                                "auto_minor_version_upgrade": true,
+                                "db_instance_class": "db.t3.micro",
+                                "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
+                                "engine": "postgres",
+                                "engine_version": "11",
+                                "engine_family": "postgres11",
+                                "multi_az": false,
                                 "skip_final_snapshot": true,
                                 "copy_tags_to_snapshot":true,
                                 "vpc_security_group_ids": [
@@ -149,6 +187,7 @@
                                 "engine": "postgres",
                                 "engine_version": "12",
                                 "engine_family": "postgres12",
+                                "multi_az": false,
                                 "copy_tags_to_snapshot":true,
                                 "vpc_security_group_ids": [
                                     "POPULATED_BY_TEST_SUITE"
@@ -179,6 +218,7 @@
                                 "engine": "postgres",
                                 "engine_version": "12",
                                 "engine_family": "postgres12",
+                                "multi_az": false,
                                 "skip_final_snapshot": true,
                                 "copy_tags_to_snapshot":true,
                                 "vpc_security_group_ids": [
@@ -209,6 +249,7 @@
                                 "engine": "postgres",
                                 "engine_version": "13",
                                 "engine_family": "postgres13",
+                                "multi_az": false,
                                 "copy_tags_to_snapshot":true,
                                 "vpc_security_group_ids": [
                                     "POPULATED_BY_TEST_SUITE"
@@ -239,6 +280,7 @@
                                 "engine": "postgres",
                                 "engine_version": "13",
                                 "engine_family": "postgres13",
+                                "multi_az": false,
                                 "skip_final_snapshot": true,
                                 "copy_tags_to_snapshot":true,
                                 "vpc_security_group_ids": [
@@ -277,6 +319,7 @@
                                 "engine": "mysql",
                                 "engine_version": "5.7",
                                 "engine_family": "mysql5.7",
+                                "multi_az": false,
                                 "copy_tags_to_snapshot":true,
                                 "vpc_security_group_ids": [
                                     "POPULATED_BY_TEST_SUITE"
@@ -296,6 +339,7 @@
                                 "engine": "mysql",
                                 "engine_version": "5.7",
                                 "engine_family": "mysql5.7",
+                                "multi_az": false,
                                 "skip_final_snapshot": true,
                                 "copy_tags_to_snapshot":true,
                                 "vpc_security_group_ids": [
@@ -316,6 +360,7 @@
                                 "engine": "mysql",
                                 "engine_version": "8.0",
                                 "engine_family": "mysql8.0",
+                                "multi_az": false,
                                 "copy_tags_to_snapshot":true,
                                 "vpc_security_group_ids": [
                                     "POPULATED_BY_TEST_SUITE"
@@ -335,6 +380,7 @@
                                 "engine": "mysql",
                                 "engine_version": "8.0",
                                 "engine_family": "mysql8.0",
+                                "multi_az": false,
                                 "skip_final_snapshot": true,
                                 "copy_tags_to_snapshot":true,
                                 "vpc_security_group_ids": [

--- a/ci/blackbox/rdsbroker_test.go
+++ b/ci/blackbox/rdsbroker_test.go
@@ -314,8 +314,8 @@ var _ = Describe("RDS Broker Daemon", func() {
 				code, operation, err := brokerAPIClient.UpdateInstance(instanceID, serviceID, startPlanID, upgradeToPlanID, `{}`)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(code).To(Equal(202))
-				extensions := pollForOperationCompletion(brokerAPIClient, instanceID, serviceID, upgradeToPlanID, operation)
-				Expect(extensions).To(Equal("succeeded"))
+				state := pollForOperationCompletion(brokerAPIClient, instanceID, serviceID, startPlanID, operation)
+				Expect(state).To(Equal("succeeded"))
 			})
 		}
 

--- a/ci/helpers/rdsclient_helper.go
+++ b/ci/helpers/rdsclient_helper.go
@@ -98,3 +98,27 @@ func (r *RDSClient) GetDBInstanceDetails(ID string) (*rds.DescribeDBInstancesOut
 
 	return r.rdssvc.DescribeDBInstances(params)
 }
+
+func (r *RDSClient) GetDBInstanceTag(ID, tagKey string) (string, error) {
+	dbInstance, err := r.GetDBInstanceDetails(ID)
+	if err != nil {
+		return "", err
+	}
+
+	listTagsForResourceInput := &rds.ListTagsForResourceInput{
+		ResourceName: dbInstance.DBInstances[0].DBInstanceArn,
+	}
+
+	listTagsForResourceOutput, err := r.rdssvc.ListTagsForResource(listTagsForResourceInput)
+	if err != nil {
+		return "", err
+	}
+
+	for _, t := range listTagsForResourceOutput.TagList {
+		if *t.Key == tagKey {
+			return *t.Value, nil
+		}
+	}
+
+	return "", nil
+}

--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -662,7 +662,7 @@ func (b *RDSBroker) Update(
 		instanceTags.SkipFinalSnapshot = strconv.FormatBool(*updateParameters.SkipFinalSnapshot)
 	}
 
-	builtTags := awsrds.BuilRDSTags(b.dbTags(instanceTags))
+	builtTags := awsrds.BuildRDSTags(b.dbTags(instanceTags))
 	b.dbInstance.AddTagsToResource(aws.StringValue(updatedDBInstance.DBInstanceArn), builtTags)
 
 	if updateParameters.Reboot != nil && *updateParameters.Reboot && !deferReboot {
@@ -1086,7 +1086,7 @@ func (b *RDSBroker) updateDBSettings(instanceID string, dbInstance *rds.DBInstan
 		ChargeableEntity: instanceID,
 	})
 
-	rdsTags := awsrds.BuilRDSTags(tags)
+	rdsTags := awsrds.BuildRDSTags(tags)
 	b.dbInstance.AddTagsToResource(aws.StringValue(updatedDBInstance.DBInstanceArn), rdsTags)
 	// AddTagsToResource error intentionally ignored - it's logged inside the method
 
@@ -1317,7 +1317,7 @@ func (b *RDSBroker) newCreateDBInstanceInput(instanceID string, servicePlan Serv
 		StorageEncrypted:           servicePlan.RDSProperties.StorageEncrypted,
 		StorageType:                servicePlan.RDSProperties.StorageType,
 		VpcSecurityGroupIds:        servicePlan.RDSProperties.VpcSecurityGroupIds,
-		Tags:                       awsrds.BuilRDSTags(b.dbTags(tags)),
+		Tags:                       awsrds.BuildRDSTags(b.dbTags(tags)),
 	}
 	if provisionParameters.PreferredBackupWindow != "" {
 		createDBInstanceInput.PreferredBackupWindow = aws.String(provisionParameters.PreferredBackupWindow)
@@ -1372,7 +1372,7 @@ func (b *RDSBroker) restoreDBInstanceInput(instanceID, snapshotIdentifier string
 		MultiAZ:                 servicePlan.RDSProperties.MultiAZ,
 		Port:                    servicePlan.RDSProperties.Port,
 		StorageType:             servicePlan.RDSProperties.StorageType,
-		Tags:                    awsrds.BuilRDSTags(b.dbTags(tags)),
+		Tags:                    awsrds.BuildRDSTags(b.dbTags(tags)),
 	}, nil
 }
 
@@ -1424,7 +1424,7 @@ func (b *RDSBroker) restoreDBInstancePointInTimeInput(instanceID, originDBIdenti
 		MultiAZ:                    servicePlan.RDSProperties.MultiAZ,
 		Port:                       servicePlan.RDSProperties.Port,
 		StorageType:                servicePlan.RDSProperties.StorageType,
-		Tags:                       awsrds.BuilRDSTags(b.dbTags(tags)),
+		Tags:                       awsrds.BuildRDSTags(b.dbTags(tags)),
 	}
 
 	if originTime != nil {

--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -361,8 +361,8 @@ func (b *RDSBroker) restoreFromSnapshot(
 		}
 
 		b.logger.Info("pruned-snapshots", lager.Data{
-			"instanceIDLogKey":     instanceID,
-			"detailsLogKey":        details,
+			instanceIDLogKey:     instanceID,
+			detailsLogKey:        details,
 			"allSnapshotsCount":    len(snapshots),
 			"prunedSnapshotsCount": len(prunedSnapshots),
 		})
@@ -377,8 +377,8 @@ func (b *RDSBroker) restoreFromSnapshot(
 	snapshot := snapshots[0]
 
 	b.logger.Info("chose-snapshot", lager.Data{
-		"instanceIDLogKey":   instanceID,
-		"detailsLogKey":      details,
+		instanceIDLogKey:   instanceID,
+		detailsLogKey:      details,
 		"snapshotIdentifier": snapshot.DBSnapshotIdentifier,
 	})
 
@@ -433,7 +433,7 @@ func (b *RDSBroker) Update(
 		asyncAllowedLogKey: asyncAllowed,
 	})
 
-	b.logger.Info("update", lager.Data{"instanceID": instanceID, "details": details})
+	b.logger.Info("update", lager.Data{instanceIDLogKey: instanceID, detailsLogKey: details})
 
 	if !asyncAllowed {
 		return brokerapi.UpdateServiceSpec{}, brokerapi.ErrAsyncRequired

--- a/rdsbroker/broker_test.go
+++ b/rdsbroker/broker_test.go
@@ -38,9 +38,11 @@ var _ = Describe("RDS Broker", func() {
 		rdsProperties1 RDSProperties
 		rdsProperties2 RDSProperties
 		rdsProperties3 RDSProperties
+		rdsProperties4 RDSProperties
 		plan1          ServicePlan
 		plan2          ServicePlan
 		plan3          ServicePlan
+		plan4          ServicePlan
 		service1       Service
 		service2       Service
 		service3       Service
@@ -153,6 +155,23 @@ var _ = Describe("RDS Broker", func() {
 				stringPointer("postgres_super_extension"),
 			},
 		}
+
+		rdsProperties4 = RDSProperties{
+			DBInstanceClass:   stringPointer("db.m3.test"),
+			Engine:            stringPointer("postgres"),
+			EngineVersion:     stringPointer("5.6.7"),
+			AllocatedStorage:  int64Pointer(300),
+			SkipFinalSnapshot: boolPointer(false),
+			DefaultExtensions: []*string{
+				stringPointer("postgis"),
+				stringPointer("pg_stat_statements"),
+			},
+			AllowedExtensions: []*string{
+				stringPointer("postgis"),
+				stringPointer("pg_stat_statements"),
+				stringPointer("postgres_super_extension"),
+			},
+		}
 	})
 
 	JustBeforeEach(func() {
@@ -174,6 +193,12 @@ var _ = Describe("RDS Broker", func() {
 			Description:   "This is the Plan 3",
 			RDSProperties: rdsProperties3,
 		}
+		plan4 = ServicePlan{
+			ID:            "Plan-4",
+			Name:          "Plan 4",
+			Description:   "This is the Plan 4",
+			RDSProperties: rdsProperties4,
+		}
 
 		service1 = Service{
 			ID:            "Service-1",
@@ -194,7 +219,7 @@ var _ = Describe("RDS Broker", func() {
 			Name:          "Service 3",
 			Description:   "This is the Service 3",
 			PlanUpdatable: planUpdateable,
-			Plans:         []ServicePlan{plan3},
+			Plans:         []ServicePlan{plan3, plan4},
 		}
 
 		catalog = Catalog{
@@ -280,6 +305,11 @@ var _ = Describe("RDS Broker", func() {
 							ID:          "Plan-3",
 							Name:        "Plan 3",
 							Description: "This is the Plan 3",
+						},
+						brokerapi.ServicePlan{
+							ID:          "Plan-4",
+							Name:        "Plan 4",
+							Description: "This is the Plan 4",
 						},
 					},
 				},
@@ -2124,6 +2154,7 @@ var _ = Describe("RDS Broker", func() {
 				DBInstanceIdentifier: aws.String(dbInstanceIdentifier),
 				DBInstanceArn:        aws.String(dbInstanceArn),
 				Engine:               aws.String("test-engine"),
+				EngineVersion:        stringPointer("4.8.9"),
 				Endpoint: &rds.Endpoint{
 					Address: aws.String("endpoint-address"),
 					Port:    aws.Int64(3306),
@@ -2137,13 +2168,19 @@ var _ = Describe("RDS Broker", func() {
 				},
 			}
 
-			defaultDBInstanceTags = []*rds.Tag{
-				{Key: aws.String("Owner"), Value: aws.String("Cloud Foundry")},
-				{Key: aws.String("Broker Name"), Value: aws.String("mybroker")},
-				{Key: aws.String("Created by"), Value: aws.String("AWS RDS Service Broker")},
-				{Key: aws.String("Service ID"), Value: aws.String("Service-1")},
-				{Key: aws.String("Plan ID"), Value: aws.String("Plan-1")},
-				{Key: aws.String("Extensions"), Value: aws.String("postgis:pg-stat-statements")},
+			defaultDBInstanceTagsByName = map[string]string{
+				"Owner": "Cloud Foundry",
+				"Broker Name": "mybroker",
+				"Created by": "AWS RDS Service Broker",
+				"Service ID": "Service-3",
+				"Plan ID": "Plan-3",
+				"Extensions": "postgis:pg-stat-statements",
+			}
+
+			pollDetails = brokerapi.PollDetails{
+				ServiceID: "Service-3",
+				PlanID: "Plan-3",
+				OperationData: "123blah",
 			}
 		)
 
@@ -2156,7 +2193,10 @@ var _ = Describe("RDS Broker", func() {
 			defaultDBInstance.DBParameterGroups[0].ParameterApplyStatus = aws.String(parameterGroupStatus)
 			rdsInstance.DescribeReturns(defaultDBInstance, nil)
 
-			rdsInstance.GetResourceTagsReturns(defaultDBInstanceTags, nil)
+			rdsInstance.GetResourceTagsReturns(
+				awsrds.BuildRDSTags(defaultDBInstanceTagsByName),
+				nil,
+			)
 
 			rdsInstance.ModifyReturns(
 				&rds.DBInstance{
@@ -2178,7 +2218,7 @@ var _ = Describe("RDS Broker", func() {
 			})
 
 			It("returns the proper error", func() {
-				_, err := rdsBroker.LastOperation(ctx, instanceID, brokerapi.PollDetails{})
+				_, err := rdsBroker.LastOperation(ctx, instanceID, pollDetails)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("operation failed"))
 			})
@@ -2189,7 +2229,7 @@ var _ = Describe("RDS Broker", func() {
 				})
 
 				It("returns the proper error", func() {
-					_, err := rdsBroker.LastOperation(ctx, instanceID, brokerapi.PollDetails{})
+					_, err := rdsBroker.LastOperation(ctx, instanceID, pollDetails)
 					Expect(err).To(HaveOccurred())
 					Expect(err).To(Equal(brokerapi.ErrInstanceDoesNotExist))
 				})
@@ -2215,7 +2255,7 @@ var _ = Describe("RDS Broker", func() {
 
 		It("returns InstanceDoesNotExist if it is not found when getting the tags", func() {
 			rdsInstance.GetResourceTagsReturns(nil, awsrds.ErrDBInstanceDoesNotExist)
-			_, err := rdsBroker.LastOperation(ctx, instanceID, brokerapi.PollDetails{})
+			_, err := rdsBroker.LastOperation(ctx, instanceID, pollDetails)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(Equal(brokerapi.ErrInstanceDoesNotExist))
 		})
@@ -2227,7 +2267,7 @@ var _ = Describe("RDS Broker", func() {
 			})
 
 			It("calls GetResourceTags() with the refresh cache option", func() {
-				lastOperationResponse, err := rdsBroker.LastOperation(ctx, instanceID, brokerapi.PollDetails{})
+				lastOperationResponse, err := rdsBroker.LastOperation(ctx, instanceID, pollDetails)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(lastOperationResponse).To(Equal(properLastOperationResponse))
 
@@ -2239,29 +2279,28 @@ var _ = Describe("RDS Broker", func() {
 			})
 
 			It("returns the proper LastOperationResponse", func() {
-				lastOperationResponse, err := rdsBroker.LastOperation(ctx, instanceID, brokerapi.PollDetails{})
+				lastOperationResponse, err := rdsBroker.LastOperation(ctx, instanceID, pollDetails)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(lastOperationResponse).To(Equal(properLastOperationResponse))
 			})
 
 			Context("and there are pending post restore tasks", func() {
 				JustBeforeEach(func() {
+					newDBInstanceTagsByName := copyStringStringMap(defaultDBInstanceTagsByName)
+					newDBInstanceTagsByName["PendingUpdateSettings"] = "true"
 					rdsInstance.GetResourceTagsReturns(
-						append(
-							defaultDBInstanceTags,
-							&rds.Tag{Key: aws.String("PendingUpdateSettings"), Value: aws.String("true")},
-						),
+						awsrds.BuildRDSTags(newDBInstanceTagsByName),
 						nil,
 					)
 				})
 				It("should not call RemoveTag to remove the tag PendingUpdateSettings", func() {
-					_, err := rdsBroker.LastOperation(ctx, instanceID, brokerapi.PollDetails{})
+					_, err := rdsBroker.LastOperation(ctx, instanceID, pollDetails)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(rdsInstance.RemoveTagCallCount()).To(Equal(0))
 				})
 
 				It("should not modify the DB instance", func() {
-					_, err := rdsBroker.LastOperation(ctx, instanceID, brokerapi.PollDetails{})
+					_, err := rdsBroker.LastOperation(ctx, instanceID, pollDetails)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(rdsInstance.ModifyCallCount()).To(Equal(0))
 				})
@@ -2275,7 +2314,7 @@ var _ = Describe("RDS Broker", func() {
 			})
 
 			It("reboots the database", func() {
-				lastOperationState, err := rdsBroker.LastOperation(ctx, instanceID, brokerapi.PollDetails{})
+				lastOperationState, err := rdsBroker.LastOperation(ctx, instanceID, pollDetails)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(lastOperationState.State).To(Equal(brokerapi.InProgress))
 				Expect(rdsInstance.RebootCallCount()).To(Equal(1))
@@ -2289,7 +2328,7 @@ var _ = Describe("RDS Broker", func() {
 			})
 
 			It("reboots the database", func() {
-				lastOperationState, err := rdsBroker.LastOperation(ctx, instanceID, brokerapi.PollDetails{})
+				lastOperationState, err := rdsBroker.LastOperation(ctx, instanceID, pollDetails)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(lastOperationState.State).To(Equal(brokerapi.InProgress))
 				Expect(rdsInstance.RebootCallCount()).To(Equal(0))
@@ -2303,7 +2342,7 @@ var _ = Describe("RDS Broker", func() {
 			})
 
 			It("returns the proper LastOperationResponse", func() {
-				lastOperationResponse, err := rdsBroker.LastOperation(ctx, instanceID, brokerapi.PollDetails{})
+				lastOperationResponse, err := rdsBroker.LastOperation(ctx, instanceID, pollDetails)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(lastOperationResponse).To(Equal(properLastOperationResponse))
 			})
@@ -2316,7 +2355,7 @@ var _ = Describe("RDS Broker", func() {
 			})
 
 			It("returns the proper LastOperationResponse", func() {
-				lastOperationResponse, err := rdsBroker.LastOperation(ctx, instanceID, brokerapi.PollDetails{})
+				lastOperationResponse, err := rdsBroker.LastOperation(ctx, instanceID, pollDetails)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(lastOperationResponse).To(Equal(properLastOperationResponse))
 			})
@@ -2328,7 +2367,7 @@ var _ = Describe("RDS Broker", func() {
 				})
 
 				It("attempts to create Postgres extenions", func() {
-					lastOperationResponse, err := rdsBroker.LastOperation(ctx, instanceID, brokerapi.PollDetails{})
+					lastOperationResponse, err := rdsBroker.LastOperation(ctx, instanceID, pollDetails)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(sqlEngine.CreateExtensionsCalled).To(BeTrue())
 					Expect(lastOperationResponse).To(Equal(properLastOperationResponse))
@@ -2350,7 +2389,7 @@ var _ = Describe("RDS Broker", func() {
 				})
 
 				It("returns the proper LastOperationResponse", func() {
-					lastOperationResponse, err := rdsBroker.LastOperation(ctx, instanceID, brokerapi.PollDetails{})
+					lastOperationResponse, err := rdsBroker.LastOperation(ctx, instanceID, pollDetails)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(lastOperationResponse).To(Equal(properLastOperationResponse))
 				})
@@ -2360,18 +2399,17 @@ var _ = Describe("RDS Broker", func() {
 				newDBInstance := *defaultDBInstance
 				newDBInstance.PendingModifiedValues = &rds.PendingModifiedValues{}
 				rdsInstance.DescribeReturns(&newDBInstance, nil)
-				lastOperationResponse, err := rdsBroker.LastOperation(ctx, instanceID, brokerapi.PollDetails{})
+				lastOperationResponse, err := rdsBroker.LastOperation(ctx, instanceID, pollDetails)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(lastOperationResponse).To(Equal(properLastOperationResponse))
 			})
 
 			Context("but there are pending post restore tasks", func() {
 				JustBeforeEach(func() {
+					newDBInstanceTagsByName := copyStringStringMap(defaultDBInstanceTagsByName)
+					newDBInstanceTagsByName["PendingUpdateSettings"] = "true"
 					rdsInstance.GetResourceTagsReturns(
-						append(
-							defaultDBInstanceTags,
-							&rds.Tag{Key: aws.String("PendingUpdateSettings"), Value: aws.String("true")},
-						),
+						awsrds.BuildRDSTags(newDBInstanceTagsByName),
 						nil,
 					)
 
@@ -2381,7 +2419,7 @@ var _ = Describe("RDS Broker", func() {
 					}
 				})
 				It("should call RemoveTag to remove the tag PendingUpdateSettings", func() {
-					_, err := rdsBroker.LastOperation(ctx, instanceID, brokerapi.PollDetails{})
+					_, err := rdsBroker.LastOperation(ctx, instanceID, pollDetails)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(rdsInstance.RemoveTagCallCount()).To(Equal(1))
 					id, tagName := rdsInstance.RemoveTagArgsForCall(0)
@@ -2390,7 +2428,7 @@ var _ = Describe("RDS Broker", func() {
 				})
 
 				It("should return the proper LastOperationResponse", func() {
-					lastOperationResponse, err := rdsBroker.LastOperation(ctx, instanceID, brokerapi.PollDetails{})
+					lastOperationResponse, err := rdsBroker.LastOperation(ctx, instanceID, pollDetails)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(lastOperationResponse).To(Equal(properLastOperationResponse))
 				})
@@ -2400,14 +2438,14 @@ var _ = Describe("RDS Broker", func() {
 						rdsInstance.RemoveTagReturns(errors.New("Failed to remove tag"))
 					})
 					It("returns the proper error", func() {
-						_, err := rdsBroker.LastOperation(ctx, instanceID, brokerapi.PollDetails{})
+						_, err := rdsBroker.LastOperation(ctx, instanceID, pollDetails)
 						Expect(err).To(HaveOccurred())
 						Expect(err.Error()).To(Equal("Failed to remove tag"))
 					})
 				})
 
 				It("modifies the DB instance", func() {
-					_, err := rdsBroker.LastOperation(ctx, instanceID, brokerapi.PollDetails{})
+					_, err := rdsBroker.LastOperation(ctx, instanceID, pollDetails)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(rdsInstance.ModifyCallCount()).To(Equal(1))
 					input := rdsInstance.ModifyArgsForCall(0)
@@ -2415,7 +2453,7 @@ var _ = Describe("RDS Broker", func() {
 				})
 
 				It("sets the right tags", func() {
-					_, err := rdsBroker.LastOperation(ctx, instanceID, brokerapi.PollDetails{})
+					_, err := rdsBroker.LastOperation(ctx, instanceID, pollDetails)
 					Expect(err).ToNot(HaveOccurred())
 
 					Expect(rdsInstance.AddTagsToResourceCallCount()).To(Equal(1))
@@ -2427,8 +2465,8 @@ var _ = Describe("RDS Broker", func() {
 					Expect(tagsByName).To(HaveKeyWithValue("Broker Name", "mybroker"))
 					Expect(tagsByName).To(HaveKeyWithValue("Restored by", "AWS RDS Service Broker"))
 					Expect(tagsByName).To(HaveKey("Restored at"))
-					Expect(tagsByName).To(HaveKeyWithValue("Service ID", "Service-1"))
-					Expect(tagsByName).To(HaveKeyWithValue("Plan ID", "Plan-1"))
+					Expect(tagsByName).To(HaveKeyWithValue("Service ID", "Service-3"))
+					Expect(tagsByName).To(HaveKeyWithValue("Plan ID", "Plan-3"))
 					Expect(tagsByName).To(HaveKeyWithValue("chargeable_entity", instanceID))
 				})
 
@@ -2444,7 +2482,7 @@ var _ = Describe("RDS Broker", func() {
 					})
 
 					It("should try to change the master password", func() {
-						_, err := rdsBroker.LastOperation(ctx, instanceID, brokerapi.PollDetails{})
+						_, err := rdsBroker.LastOperation(ctx, instanceID, pollDetails)
 						Expect(err).ToNot(HaveOccurred())
 						Expect(rdsInstance.ModifyCallCount()).To(Equal(1))
 						input := rdsInstance.ModifyArgsForCall(0)
@@ -2455,11 +2493,11 @@ var _ = Describe("RDS Broker", func() {
 
 				Context("when has DBSecurityGroups", func() {
 					BeforeEach(func() {
-						rdsProperties1.DBSecurityGroups = []*string{aws.String("test-db-security-group")}
+						rdsProperties3.DBSecurityGroups = []*string{aws.String("test-db-security-group")}
 					})
 
 					It("makes the modify with the security group", func() {
-						_, err := rdsBroker.LastOperation(ctx, instanceID, brokerapi.PollDetails{})
+						_, err := rdsBroker.LastOperation(ctx, instanceID, pollDetails)
 						Expect(err).ToNot(HaveOccurred())
 						Expect(rdsInstance.ModifyCallCount()).To(Equal(1))
 						input := rdsInstance.ModifyArgsForCall(0)
@@ -2472,11 +2510,10 @@ var _ = Describe("RDS Broker", func() {
 
 			Context("but there are pending reboot", func() {
 				JustBeforeEach(func() {
+					newDBInstanceTagsByName := copyStringStringMap(defaultDBInstanceTagsByName)
+					newDBInstanceTagsByName["PendingReboot"] = "true"
 					rdsInstance.GetResourceTagsReturns(
-						append(
-							defaultDBInstanceTags,
-							&rds.Tag{Key: aws.String("PendingReboot"), Value: aws.String("true")},
-						),
+						awsrds.BuildRDSTags(newDBInstanceTagsByName),
 						nil,
 					)
 
@@ -2487,7 +2524,7 @@ var _ = Describe("RDS Broker", func() {
 				})
 
 				It("should call RemoveTag to remove the tag PendingReboot", func() {
-					_, err := rdsBroker.LastOperation(ctx, instanceID, brokerapi.PollDetails{})
+					_, err := rdsBroker.LastOperation(ctx, instanceID, pollDetails)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(rdsInstance.RemoveTagCallCount()).To(Equal(1))
 					id, tagName := rdsInstance.RemoveTagArgsForCall(0)
@@ -2496,7 +2533,7 @@ var _ = Describe("RDS Broker", func() {
 				})
 
 				It("should return the proper LastOperationResponse", func() {
-					lastOperationResponse, err := rdsBroker.LastOperation(ctx, instanceID, brokerapi.PollDetails{})
+					lastOperationResponse, err := rdsBroker.LastOperation(ctx, instanceID, pollDetails)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(lastOperationResponse).To(Equal(properLastOperationResponse))
 				})
@@ -2506,14 +2543,14 @@ var _ = Describe("RDS Broker", func() {
 						rdsInstance.RemoveTagReturns(errors.New("Failed to remove tag"))
 					})
 					It("returns the proper error", func() {
-						_, err := rdsBroker.LastOperation(ctx, instanceID, brokerapi.PollDetails{})
+						_, err := rdsBroker.LastOperation(ctx, instanceID, pollDetails)
 						Expect(err).To(HaveOccurred())
 						Expect(err.Error()).To(Equal("Failed to remove tag"))
 					})
 				})
 
 				It("reboot the DB instance", func() {
-					_, err := rdsBroker.LastOperation(ctx, instanceID, brokerapi.PollDetails{})
+					_, err := rdsBroker.LastOperation(ctx, instanceID, pollDetails)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(rdsInstance.RebootCallCount()).To(Equal(1))
 					input := rdsInstance.RebootArgsForCall(0)
@@ -2523,11 +2560,10 @@ var _ = Describe("RDS Broker", func() {
 
 			Context("but there is a pending reset user password", func() {
 				JustBeforeEach(func() {
+					newDBInstanceTagsByName := copyStringStringMap(defaultDBInstanceTagsByName)
+					newDBInstanceTagsByName["PendingResetUserPassword"] = "true"
 					rdsInstance.GetResourceTagsReturns(
-						append(
-							defaultDBInstanceTags,
-							&rds.Tag{Key: aws.String("PendingResetUserPassword"), Value: aws.String("true")},
-						),
+						awsrds.BuildRDSTags(newDBInstanceTagsByName),
 						nil,
 					)
 
@@ -2538,7 +2574,7 @@ var _ = Describe("RDS Broker", func() {
 				})
 
 				It("should call RemoveTag to remove the tag PendingResetUserPassword", func() {
-					_, err := rdsBroker.LastOperation(ctx, instanceID, brokerapi.PollDetails{})
+					_, err := rdsBroker.LastOperation(ctx, instanceID, pollDetails)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(rdsInstance.RemoveTagCallCount()).To(Equal(1))
 					id, tagName := rdsInstance.RemoveTagArgsForCall(0)
@@ -2547,7 +2583,7 @@ var _ = Describe("RDS Broker", func() {
 				})
 
 				It("should return the proper LastOperationResponse", func() {
-					lastOperationResponse, err := rdsBroker.LastOperation(ctx, instanceID, brokerapi.PollDetails{})
+					lastOperationResponse, err := rdsBroker.LastOperation(ctx, instanceID, pollDetails)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(lastOperationResponse).To(Equal(properLastOperationResponse))
 				})
@@ -2557,14 +2593,14 @@ var _ = Describe("RDS Broker", func() {
 						rdsInstance.RemoveTagReturns(errors.New("Failed to remove tag"))
 					})
 					It("returns the proper error", func() {
-						_, err := rdsBroker.LastOperation(ctx, instanceID, brokerapi.PollDetails{})
+						_, err := rdsBroker.LastOperation(ctx, instanceID, pollDetails)
 						Expect(err).To(HaveOccurred())
 						Expect(err.Error()).To(Equal("Failed to remove tag"))
 					})
 				})
 
 				It("should reset the database state by calling sqlengine.ResetState()", func() {
-					_, err := rdsBroker.LastOperation(ctx, instanceID, brokerapi.PollDetails{})
+					_, err := rdsBroker.LastOperation(ctx, instanceID, pollDetails)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(sqlEngine.ResetStateCalled).To(BeTrue())
 				})
@@ -2574,7 +2610,7 @@ var _ = Describe("RDS Broker", func() {
 						sqlEngine.ResetStateError = errors.New("Failed to reset state")
 					})
 					It("returns the proper error", func() {
-						_, err := rdsBroker.LastOperation(ctx, instanceID, brokerapi.PollDetails{})
+						_, err := rdsBroker.LastOperation(ctx, instanceID, pollDetails)
 						Expect(err).To(HaveOccurred())
 						Expect(err.Error()).To(Equal("Failed to reset state"))
 					})
@@ -2583,17 +2619,17 @@ var _ = Describe("RDS Broker", func() {
 
 			Context("but there are not post restore tasks or reset password to execute", func() {
 				It("should not try to change the master password", func() {
-					_, err := rdsBroker.LastOperation(ctx, instanceID, brokerapi.PollDetails{})
+					_, err := rdsBroker.LastOperation(ctx, instanceID, pollDetails)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(rdsInstance.ModifyCallCount()).To(Equal(0))
 				})
 				It("should not reset the database state by not calling sqlengine.ResetState()", func() {
-					_, err := rdsBroker.LastOperation(ctx, instanceID, brokerapi.PollDetails{})
+					_, err := rdsBroker.LastOperation(ctx, instanceID, pollDetails)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(sqlEngine.ResetStateCalled).To(BeFalse())
 				})
 				It("should not call RemoveTag", func() {
-					_, err := rdsBroker.LastOperation(ctx, instanceID, brokerapi.PollDetails{})
+					_, err := rdsBroker.LastOperation(ctx, instanceID, pollDetails)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(rdsInstance.RemoveTagCallCount()).To(Equal(0))
 				})
@@ -2608,7 +2644,7 @@ var _ = Describe("RDS Broker", func() {
 				})
 
 				It("returns the state "+string(expectedLastOperationState), func() {
-					lastOperationResponse, err := rdsBroker.LastOperation(ctx, instanceID, brokerapi.PollDetails{})
+					lastOperationResponse, err := rdsBroker.LastOperation(ctx, instanceID, pollDetails)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(lastOperationResponse).To(Equal(properLastOperationResponse))
 				})
@@ -2778,8 +2814,8 @@ var _ = Describe("RDS Broker", func() {
 				rdsInstance.DescribeReturns(dbInstance, nil)
 
 				bindDetails = brokerapi.BindDetails{
-					ServiceID:     "Service-1",
-					PlanID:        "Plan-1",
+					ServiceID:     "Service-3",
+					PlanID:        "Plan-3",
 					AppGUID:       "Application-1",
 					RawParameters: json.RawMessage("{}"),
 				}

--- a/rdsbroker/broker_test.go
+++ b/rdsbroker/broker_test.go
@@ -420,7 +420,7 @@ var _ = Describe("RDS Broker", func() {
 					DBInstanceArn:        aws.String(restoreFromPointInTimeDBInstanceARN),
 					DBInstanceIdentifier: aws.String(restoreFromPointInTimeDBInstanceID),
 				}, nil)
-				rdsInstance.GetResourceTagsReturns(awsrds.BuilRDSTags(dbIdentifierTags), nil)
+				rdsInstance.GetResourceTagsReturns(awsrds.BuildRDSTags(dbIdentifierTags), nil)
 			})
 
 			Context("and the restore_from_latest_snapshot_of also present", func() {
@@ -621,7 +621,7 @@ var _ = Describe("RDS Broker", func() {
 					},
 				}, nil)
 
-				rdsInstance.GetResourceTagsReturns(awsrds.BuilRDSTags(dbSnapshotTags), nil)
+				rdsInstance.GetResourceTagsReturns(awsrds.BuildRDSTags(dbSnapshotTags), nil)
 			})
 
 			Context("without a restore_from_latest_snapshot_before modifier", func() {
@@ -772,7 +772,7 @@ var _ = Describe("RDS Broker", func() {
 				Context("when the snapshot had extensions enabled", func() {
 					It("sets the same extensions on the new database", func() {
 						dbSnapshotTags[awsrds.TagExtensions] = "foo:bar"
-						rdsInstance.GetResourceTagsReturns(awsrds.BuilRDSTags(dbSnapshotTags), nil)
+						rdsInstance.GetResourceTagsReturns(awsrds.BuildRDSTags(dbSnapshotTags), nil)
 
 						_, err := rdsBroker.Provision(ctx, instanceID, provisionDetails, acceptsIncomplete)
 
@@ -790,7 +790,7 @@ var _ = Describe("RDS Broker", func() {
 						})
 						It("adds those extensions to the set of extensions on the snapshot", func() {
 							dbSnapshotTags[awsrds.TagExtensions] = "foo:bar"
-							rdsInstance.GetResourceTagsReturns(awsrds.BuilRDSTags(dbSnapshotTags), nil)
+							rdsInstance.GetResourceTagsReturns(awsrds.BuildRDSTags(dbSnapshotTags), nil)
 
 							_, err := rdsBroker.Provision(ctx, instanceID, provisionDetails, acceptsIncomplete)
 

--- a/rdsbroker/broker_update_test.go
+++ b/rdsbroker/broker_update_test.go
@@ -1131,7 +1131,7 @@ var _ = Describe("RDS Broker", func() {
 				dbTags := map[string]string{
 					awsrds.TagExtensions: "postgis:pg_stat_statements",
 				}
-				rdsInstance.GetResourceTagsReturns(awsrds.BuilRDSTags(dbTags), nil)
+				rdsInstance.GetResourceTagsReturns(awsrds.BuildRDSTags(dbTags), nil)
 			})
 
 			It("successfully sets an extension", func() {
@@ -1215,7 +1215,7 @@ var _ = Describe("RDS Broker", func() {
 				dbTags := map[string]string{
 					awsrds.TagExtensions: "postgis:pg_stat_statements:postgres_super_extension",
 				}
-				rdsInstance.GetResourceTagsReturns(awsrds.BuilRDSTags(dbTags), nil)
+				rdsInstance.GetResourceTagsReturns(awsrds.BuildRDSTags(dbTags), nil)
 				newParamGroupName = "updatedParamGroupName"
 			})
 

--- a/rdsbroker/helpers_test.go
+++ b/rdsbroker/helpers_test.go
@@ -9,3 +9,16 @@ func int64Pointer(input int64) *int64 {
 func stringPointer(input string) *string {
 	return &input
 }
+
+// copyStringStringMap ensures we copy the map, instead of the reference to the map.
+// apparently copying a map is "such an uncommon operation" it's ok to require a
+// loop for this in go land.
+func copyStringStringMap(inMap map[string]string) map[string]string {
+	outMap := map[string]string{}
+
+	for key, value := range inMap {
+		outMap[key] = value
+	}
+
+	return outMap
+}


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/179954369

Currently a version-upgrading plan change that fails will interpret it as a success due to the instance status returning to "available" after Amazon have given up trying to migrate it. This leads to a lot of confusion for the tenant,

 - firstly because any further attempts to update the database's configuration will quietly re-attempt to perform the migration, likely failing due to a minor version mismatch. The 500 that this causes doesn't signal to the CC that it should stop attempting this, and it continues retrying behind the scenes ad nauseam.
 - secondly because CF claims it to be happily running the new version - but it isn't

The first problem is mitigated slightly here by fixing the `Update` endpoint to return a 422 when RDS flat-refuses to perform a requested modification. This should hopefully result in immediate, synchronous failure which is generally a much better experience.

~The second problem can't actually be _fixed_ easily because the service broker protocol lacks the ability for an asynchronous operation to report back a plan-rollback to the CC. But what we *can* do is give the user an accurate error message and tell them to contact support, who will need to manually reset the service instance's "plan id" in the CC database (*and* roll back the instances AWS tags) before it will let the user re-attempt the upgrade (or do anything else for that matter).~

~The second problem is addressed by detecting the failure in the `LastOperation` polling and responding with `brokerapi.Failed`, which will prevent the CC from updating its record of this instance's plan. The failure can be detected by comparing the `EngineVersion` associated with the `Plan ID` stored in the aws tags with the `EngineVersion` that the instance now appears to be running after the instance goes back to the "available" state. The aws tag is the only record we have at this point of what the "new" plan is supposed to be.~

The second problem is addressed by ensuring in the `LastOperation` polling that the RDS instance's properties closely match those of the _destination_ plan (using a new function `compareDBDescriptionWithPlan`) before declaring success. If there is a mismatch from the expected destination plan properties after the RDS instance goes back into an "available" state, we first check whether the properties instead closely match those of the "old" plan id. In this simple case we can just declare the operation to have failed, roll back the `Plan ID` tag and allow the user to try again. If the properties match neither plan (as might be the case if a "complex" plan change, i.e. one affecting multiple properties, had semi-failed) all we can do is suggest the user contacts support, who will then have to decide how best to tidy up the mess.

Some unrelated fixes are also made in this PR - log message keys used in the database restore functionality were incorrect.

# How to review

Deploy to a dev env and try upgrading a postgres 10 service with the `tsearch2` extension to postgres 11 and see if the resulting failure behaves as expected.

Don't be surprised if what you expect to be a "simple" failure (i.e. one that gets rolled back) shows up as a "complex" failure, because there are quite a few subtle differences between our postgres 10 and 11 plans including instance class.