### PR TITLE
180546309 - Prevent access to postgres database for users

### DIFF
--- a/ci/blackbox/rdsbroker_test.go
+++ b/ci/blackbox/rdsbroker_test.go
@@ -1067,6 +1067,14 @@ func permissionsTest(databaseURI string) error {
 		if err != nil {
 			return fmt.Errorf("Error dropping schema: %s", err.Error())
 		}
+
+		dbURLPostgres := dbURL
+		dbURLPostgres.Path = "postgres"
+		dbPostgres, err := openConnection(dbURLPostgres.String())
+		if err != nil {
+			dbPostgres.Close()
+			return fmt.Errorf("Should not be able to connect to `postgres` database, but attempt was successful")
+		}
 	case "mysql":
 		// There are no MySQL-specific tests
 	default:

--- a/sqlengine/postgres_engine.go
+++ b/sqlengine/postgres_engine.go
@@ -95,6 +95,14 @@ func (d *PostgresEngine) execCreateUser(logger lager.Logger, tx *sql.Tx, binding
 		return "", "", err
 	}
 
+	revokeConnectOnPostgresDatabaseStatement := `revoke connect on database postgres from public`
+	logger.Debug("revoke-connect", lager.Data{"statement": revokeConnectOnPostgresDatabaseStatement})
+
+	if _, err := tx.Exec(revokeConnectOnPostgresDatabaseStatement); err != nil {
+		logger.Error("Revoke sql-error", err)
+		return "", "", err
+	}
+
 	if readOnly {
 		grantPrivilegesStatement := fmt.Sprintf(
 			`grant %s to %s`,

--- a/sqlengine/postgres_engine_test.go
+++ b/sqlengine/postgres_engine_test.go
@@ -283,6 +283,16 @@ var _ = Describe("PostgresEngine", func() {
 
 		})
 
+		It("creates a user that can't connect to the postgres database", func() {
+			postgresDbname := "postgres"
+			connectionString := postgresEngine.URI(address, port, postgresDbname, createdUser, createdPassword)
+			db, err := sql.Open("postgres", connectionString)
+			Expect(err).ToNot(HaveOccurred())
+			err = db.Ping()
+			Expect(err).To(HaveOccurred())
+			defer db.Close()
+		})
+
 		Context("When the user is read only", func() {
 			var (
 				roBindingID       string


### PR DESCRIPTION
Description:
- Revokes CONNECT access from the PUBLIC group (implicity defined group that includes all roles) which prevents non-admin users from connecting to the postgres database