### PR TITLE
AWS tag cache improvements

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -36,6 +36,10 @@ jobs:
         run: |
           make start_postgres_12 run_postgres_sql_tests stop_postgres_12
 
+      - name: Run postgres 13 tests
+        run: |
+          make start_postgres_13 run_postgres_sql_tests stop_postgres_13
+
       - name: Run mysql 8.0
         run: |
           make start_mysql_80 run_mysql_sql_tests stop_mysql_80

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -26,6 +26,7 @@ A sample configuration can be found at [config-sample.json](https://github.com/a
 | allow_user_bind_parameters     | N        | Boolean | Allow users to send arbitrary parameters on bind calls (defaults to `false`)
 | catalog                        | Y        | Hash    | [RDS Broker catalog](https://github.com/alphagov/paas-rds-broker/blob/master/CONFIGURATION.md#rds-broker-catalog)
 | master_password_seed           | Y        | String  | Seed to generate DB instances master passwords
+| aws_tag_cache_seconds          | N        | Integer | Cache expiry time of AWS Tags cache (in seconds)
 | broker_name                    | Y        | String  | RDS broker name used to tag instances for identification
 
 ### Note

--- a/awsrds/db_instance.go
+++ b/awsrds/db_instance.go
@@ -10,8 +10,7 @@ import (
 type DescribeOption string
 
 const (
-	// Should Describe* ops invalidate and refresh the cache
-	DescribeRefreshCacheOption DescribeOption = "refreshCache"
+	DescribeUseCachedOption DescribeOption = "useCached"
 )
 
 //go:generate counterfeiter -o fakes/fake_rds_instance.go . RDSInstance

--- a/awsrds/rds_db_instance.go
+++ b/awsrds/rds_db_instance.go
@@ -27,12 +27,23 @@ const (
 )
 
 type RDSDBInstance struct {
-	region         string
-	partition      string
-	rdssvc         *rds.RDS
-	cachedTags     map[string][]*rds.Tag
-	cachedTagsLock sync.RWMutex
-	logger         lager.Logger
+	region           string
+	partition        string
+	rdssvc           *rds.RDS
+	cachedTags       map[string]tagCacheEntry
+	cachedTagsLock   sync.RWMutex
+	logger           lager.Logger
+	timeNowFunc      func() time.Time
+	tagCacheDuration time.Duration
+}
+
+type tagCacheEntry struct {
+	tags        []*rds.Tag
+	requestTime time.Time
+}
+
+func (e *tagCacheEntry) HasExpired(now time.Time, duration time.Duration) bool {
+    return now.After(e.requestTime.Add(duration))
 }
 
 func NewRDSDBInstance(
@@ -40,13 +51,23 @@ func NewRDSDBInstance(
 	partition string,
 	rdssvc *rds.RDS,
 	logger lager.Logger,
+	tagCacheDuration time.Duration,
+	timeNowFunc func() time.Time,
 ) *RDSDBInstance {
+	if timeNowFunc == nil {
+		timeNowFunc = func() time.Time {
+			return time.Now()
+		}
+	}
+
 	return &RDSDBInstance{
-		region:     region,
-		partition:  partition,
-		rdssvc:     rdssvc,
-		cachedTags: map[string][]*rds.Tag{},
-		logger:     logger.Session("db-instance"),
+		region:           region,
+		partition:        partition,
+		rdssvc:           rdssvc,
+		cachedTags:       map[string]tagCacheEntry{},
+		logger:           logger.Session("db-instance"),
+		tagCacheDuration: tagCacheDuration,
+		timeNowFunc:      timeNowFunc,
 	}
 }
 
@@ -150,7 +171,7 @@ func (r *RDSDBInstance) DescribeSnapshots(DBInstanceID string) ([]*rds.DBSnapsho
 func (r *RDSDBInstance) DeleteSnapshots(brokerName string, keepForDays int) error {
 	r.logger.Info("delete-snapshots", lager.Data{"broker_name": brokerName, "keep_for_days": keepForDays})
 
-	deleteBefore := time.Now().Add(-1 * time.Duration(keepForDays) * 24 * time.Hour)
+	deleteBefore := r.timeNowFunc().Add(-1 * time.Duration(keepForDays) * 24 * time.Hour)
 
 	oldSnapshots := []*rds.DBSnapshot{}
 
@@ -441,17 +462,21 @@ func (r *RDSDBInstance) dbSnapshotName(ID string) string {
 func (r *RDSDBInstance) cachedListTagsForResource(arn string, useCached bool) ([]*rds.Tag, error) {
 	if useCached {
 		r.cachedTagsLock.RLock()
-		tags, ok := r.cachedTags[arn]
+		entry, ok := r.cachedTags[arn]
 		r.cachedTagsLock.RUnlock()
-		if ok {
-			return tags, nil
+		if ok && !entry.HasExpired(r.timeNowFunc(), r.tagCacheDuration) {
+			return entry.tags, nil
 		}
 	}
 
 	tags, err := ListTagsForResource(arn, r.rdssvc, r.logger)
 	if err == nil {
+		entry := tagCacheEntry{
+			tags: tags,
+			requestTime: r.timeNowFunc(),
+		}
 		r.cachedTagsLock.Lock()
-		r.cachedTags[arn] = tags
+		r.cachedTags[arn] = entry
 		r.cachedTagsLock.Unlock()
 	}
 	return tags, err

--- a/awsrds/rds_db_instance_test.go
+++ b/awsrds/rds_db_instance_test.go
@@ -207,18 +207,26 @@ var _ = Describe("RDS DB Instance", func() {
 			Expect(aws.StringValue(receivedListTagsForResourceInput.ResourceName)).To(Equal(dbInstanceArn))
 		})
 
-		It("caches the tags from ListTagsForResource unless DescribeRefreshCacheOption is passed", func() {
-			tags, err := rdsDBInstance.GetResourceTags(dbInstanceArn)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(tags).To(Equal(listTags))
-
-			tags, err = rdsDBInstance.GetResourceTags(dbInstanceArn)
+		It("caches the tags from ListTagsForResource if DescribeUseCachedOption is passed", func() {
+			tags, err := rdsDBInstance.GetResourceTags(
+				dbInstanceArn,
+				DescribeUseCachedOption,
+			)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(tags).To(Equal(listTags))
 
 			Expect(listTagsForResourceCallCount).To(Equal(1))
 
-			tags, err = rdsDBInstance.GetResourceTags(dbInstanceArn, DescribeRefreshCacheOption)
+			tags, err = rdsDBInstance.GetResourceTags(
+				dbInstanceArn,
+				DescribeUseCachedOption,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(tags).To(Equal(listTags))
+
+			Expect(listTagsForResourceCallCount).To(Equal(1))
+
+			tags, err = rdsDBInstance.GetResourceTags(dbInstanceArn)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(tags).To(Equal(listTags))
 
@@ -385,25 +393,25 @@ var _ = Describe("RDS DB Instance", func() {
 			Expect(dbInstanceDetailsList[1]).To(Equal(db2))
 		})
 
-		It("caches the tags from ListTagsForResource unless DescribeRefreshCacheOption is passed", func() {
+		It("uses cached tags from ListTagsForResource if DescribeUseCachedOption is passed", func() {
 			numberOfInstances := 3
 
 			listTagsForResourceCallCount = 0
-			dbInstanceDetailsList, err := rdsDBInstance.DescribeByTag("Broker Name", "mybroker")
+			dbInstanceDetailsList, err := rdsDBInstance.DescribeByTag("Broker Name", "mybroker", DescribeUseCachedOption)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(dbInstanceDetailsList).To(HaveLen(2))
 
 			Expect(listTagsForResourceCallCount).To(Equal(numberOfInstances))
 
 			listTagsForResourceCallCount = 0
-			dbInstanceDetailsList, err = rdsDBInstance.DescribeByTag("Broker Name", "mybroker")
+			dbInstanceDetailsList, err = rdsDBInstance.DescribeByTag("Broker Name", "mybroker", DescribeUseCachedOption)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(dbInstanceDetailsList).To(HaveLen(2))
 
 			Expect(listTagsForResourceCallCount).To(Equal(0))
 
 			listTagsForResourceCallCount = 0
-			dbInstanceDetailsList, err = rdsDBInstance.DescribeByTag("Broker Name", "mybroker", DescribeRefreshCacheOption)
+			dbInstanceDetailsList, err = rdsDBInstance.DescribeByTag("Broker Name", "mybroker")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(dbInstanceDetailsList).To(HaveLen(2))
 

--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -881,7 +881,6 @@ func (b *RDSBroker) LastOperation(
 
 	tags, err := b.dbInstance.GetResourceTags(
 		aws.StringValue(dbInstance.DBInstanceArn),
-		awsrds.DescribeRefreshCacheOption,
 	)
 	if err != nil {
 		if err == awsrds.ErrDBInstanceDoesNotExist {
@@ -1272,7 +1271,11 @@ func (b *RDSBroker) RebootIfRequired(instanceID string, dbInstance *rds.DBInstan
 func (b *RDSBroker) CheckAndRotateCredentials() {
 	b.logger.Info(fmt.Sprintf("Started checking credentials of RDS instances managed by this broker"))
 
-	dbInstances, err := b.dbInstance.DescribeByTag("Broker Name", b.brokerName)
+	dbInstances, err := b.dbInstance.DescribeByTag(
+		"Broker Name",
+		b.brokerName,
+		awsrds.DescribeUseCachedOption,
+	)
 	if err != nil {
 		b.logger.Error("Could not obtain the list of instances", err)
 		return

--- a/rdsbroker/broker_test.go
+++ b/rdsbroker/broker_test.go
@@ -2309,7 +2309,7 @@ var _ = Describe("RDS Broker", func() {
 				lastOperationState = domain.InProgress
 			})
 
-			It("calls GetResourceTags() with the refresh cache option", func() {
+			It("calls GetResourceTags() without the use cached option", func() {
 				lastOperationResponse, err := rdsBroker.LastOperation(ctx, instanceID, pollDetails)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(lastOperationResponse).To(Equal(properLastOperationResponse))
@@ -2318,7 +2318,7 @@ var _ = Describe("RDS Broker", func() {
 				id, opts := rdsInstance.GetResourceTagsArgsForCall(0)
 				Expect(id).To(Equal(dbInstanceArn))
 
-				Expect(opts).To(ContainElement(awsrds.DescribeRefreshCacheOption))
+				Expect(opts).ToNot(ContainElement(awsrds.DescribeUseCachedOption))
 			})
 
 			It("returns the proper LastOperationResponse", func() {
@@ -2847,7 +2847,7 @@ var _ = Describe("RDS Broker", func() {
 				key, value, opts := rdsInstance.DescribeByTagArgsForCall(0)
 				Expect(key).To(BeEquivalentTo("Broker Name"))
 				Expect(value).To(BeEquivalentTo(brokerName))
-				Expect(opts).To(BeEmpty())
+				Expect(opts).To(ContainElement(awsrds.DescribeUseCachedOption))
 
 				Expect(sqlProvider.GetSQLEngineCalled).To(BeTrue())
 				Expect(sqlProvider.GetSQLEngineEngine).To(BeEquivalentTo("fake-engine"))

--- a/rdsbroker/config.go
+++ b/rdsbroker/config.go
@@ -11,6 +11,7 @@ type Config struct {
 	BrokerName                   string  `json:"broker_name"`
 	AWSPartition                 string  `json:"aws_partition"`
 	MasterPasswordSeed           string  `json:"master_password_seed"`
+	AWSTagCacheSeconds           uint    `json:"aws_tag_cache_seconds"`
 	AllowUserProvisionParameters bool    `json:"allow_user_provision_parameters"`
 	AllowUserUpdateParameters    bool    `json:"allow_user_update_parameters"`
 	AllowUserBindParameters      bool    `json:"allow_user_bind_parameters"`
@@ -20,6 +21,9 @@ type Config struct {
 func (c *Config) FillDefaults() {
 	if c.AWSPartition == "" {
 		c.AWSPartition = "aws"
+	}
+	if c.AWSTagCacheSeconds == 0 {
+		c.AWSTagCacheSeconds = 604800;  // 1 week
 	}
 }
 

--- a/rdsbroker/fakes/fake_parameter_group_selector.go
+++ b/rdsbroker/fakes/fake_parameter_group_selector.go
@@ -38,15 +38,16 @@ func (fake *FakeParameterGroupSelector) SelectParameterGroup(arg1 rdsbroker.Serv
 		arg1 rdsbroker.ServicePlan
 		arg2 []string
 	}{arg1, arg2Copy})
+	stub := fake.SelectParameterGroupStub
+	fakeReturns := fake.selectParameterGroupReturns
 	fake.recordInvocation("SelectParameterGroup", []interface{}{arg1, arg2Copy})
 	fake.selectParameterGroupMutex.Unlock()
-	if fake.SelectParameterGroupStub != nil {
-		return fake.SelectParameterGroupStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.selectParameterGroupReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/release/jobs/rds-broker/spec
+++ b/release/jobs/rds-broker/spec
@@ -37,6 +37,9 @@ properties:
     default: "cf"
   rds-broker.master_password_seed:
     description: "Secret seed to be used when generating the master RDS DB password"
+  rds-broker.aws_tag_cache_seconds:
+    description: "Cache expiry time (in seconds) of AWS Tags cache"
+    default: 604800
   rds-broker.broker_name:
     description: "Unique name of RDS broker, used to construct a tag for instance identification"
   rds-broker.allow_user_provision_parameters:

--- a/release/jobs/rds-broker/templates/config/rds-config.json.erb
+++ b/release/jobs/rds-broker/templates/config/rds-config.json.erb
@@ -11,6 +11,7 @@
     "region": "<%= p('rds-broker.aws_region') %>",
     "db_prefix": "<%= p('rds-broker.db_prefix') %>",
     "master_password_seed": "<%= p('rds-broker.master_password_seed') %>",
+    "aws_tag_cache_seconds": <%= p('rds-broker.aws_tag_cache_seconds') %>,
     "broker_name": "<%= p('rds-broker.broker_name') %>",
     "allow_user_provision_parameters": <%= p('rds-broker.allow_user_provision_parameters') %>,
     "allow_user_update_parameters": <%= p('rds-broker.allow_user_update_parameters') %>,


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181047681

Rather than simply adding a cache timeout I made a few changes.

Most importantly I made the default calls *not* return cached values. Instead it is now an opt-in to "use cached" values. The only place I've left use of cached values in is `RDSDBInstance.DescribeByTag` as I don't think it's really safe anywhere else.

`RDSDBInstance.DescribeByTag` attempts to get tags for all databases in an account/region, but is only called by `RDSBroker.CheckAndRotateCredentials`, and this only appears to be called once at broker startup. So, while it looks like it would benefit from the cache, in reality after it has fetched tags for all RDS databases, I'm not sure that cache will get consulted again. That said, the mechanism is being left in in case we switfly regret disabling this cache due to RDS API throttling and decide to re-enable it more selectively on some calls.

Have also changed things so *all* tag fetching goes through the cache, so that we're at least updating this cache at all opportunities.

Finally, added the cache timeout mechanism, controlled using the `aws_tag_cache_seconds` configuration parameter. This is by default set to 1 week (!), because as described above, I have a feeling the only things that will make use of the cache are infrequent bulk management tasks.

# Who can review this

Anyone but @risicle and @cadmiumcat

# How to review

Run the tests, see the blackbox tests (hopefully) passing. Could deploy to a dev instance and run acceptance tests.
