### PR TITLE
BAU - Fix Go 1.18 bits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,5 @@ bosh-release-tarballs
 release/.dev_builds
 release/blobs
 release/dev_releases
+
+/.idea

--- a/ci/integration.yml
+++ b/ci/integration.yml
@@ -14,10 +14,8 @@ run:
     - -e
     - -c
     - |
-      export GOPATH=$(pwd)
-      export PATH="${GOPATH}/bin:${PATH}"
 
       go install github.com/onsi/ginkgo/ginkgo@latest
 
-      cd "${GOPATH}/src/github.com/alphagov/paas-rds-broker"
+      cd src/github.com/alphagov/paas-rds-broker
       make integration


### PR DESCRIPTION
Description:
- No need to add a GOPATH as we can use the golang docker image default