### PR TITLE
Fix unexpected rebooting message when modifying an existing rds instance

### DIFF
--- a/awsrds/rds_db_instance.go
+++ b/awsrds/rds_db_instance.go
@@ -333,6 +333,16 @@ func (r *RDSDBInstance) Modify(modifyDBInstanceInput *rds.ModifyDBInstanceInput)
 		r.logger.Info("modify-db-instance.prevented-update-same-subnetgroup", lager.Data{"input": &sanitizedDBInstanceInput})
 	}
 
+	newParameterGroup := aws.StringValue(modifyDBInstanceInput.DBParameterGroupName)
+	oldParameterGroup := ""
+	if len(oldDbInstance.DBParameterGroups) == 1 {
+		oldParameterGroup = aws.StringValue(oldDbInstance.DBParameterGroups[0].DBParameterGroupName)
+	}
+	if newParameterGroup == oldParameterGroup {
+		updatedModifyDBInstanceInput.DBParameterGroupName = nil
+		r.logger.Info("modify-db-instance.prevented-update-same-parametergroup", lager.Data{"input": &sanitizedDBInstanceInput})
+	}
+
 	modifyDBInstanceOutput, err := r.rdssvc.ModifyDBInstance(&updatedModifyDBInstanceInput)
 	if err != nil {
 		return nil, HandleAWSError(err, r.logger)

--- a/awsrds/rds_db_instance_test.go
+++ b/awsrds/rds_db_instance_test.go
@@ -749,6 +749,9 @@ var _ = Describe("RDS DB Instance", func() {
 				DBSubnetGroup: &rds.DBSubnetGroup{
 					DBSubnetGroupName: aws.String("test-subnet-group"),
 				},
+				DBParameterGroups:    []*rds.DBParameterGroupStatus{
+					&rds.DBParameterGroupStatus{DBParameterGroupName: aws.String("test-parameter-group")},
+				},
 				Engine:           aws.String("test-engine"),
 				EngineVersion:    aws.String("1.2.3"),
 				DBName:           aws.String("test-dbname"),
@@ -892,6 +895,30 @@ var _ = Describe("RDS DB Instance", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(receivedModifyDBInstanceInput).ToNot(Equal(modifyDBInstanceInput))
 			Expect(receivedModifyDBInstanceInput.DBSubnetGroupName).To(BeNil())
+		})
+
+		It("does not update ParameterGroup if it is the same", func() {
+			modifyDBInstanceInput := &rds.ModifyDBInstanceInput{
+				DBInstanceIdentifier: aws.String(dbInstanceIdentifier),
+				DBParameterGroupName: aws.String("test-parameter-group"),
+			}
+
+			_, err := rdsDBInstance.Modify(modifyDBInstanceInput)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(receivedModifyDBInstanceInput).ToNot(Equal(modifyDBInstanceInput))
+			Expect(receivedModifyDBInstanceInput.DBParameterGroupName).To(BeNil())
+		})
+
+		It("does update ParameterGroup if it different", func() {
+			modifyDBInstanceInput := &rds.ModifyDBInstanceInput{
+				DBInstanceIdentifier: aws.String(dbInstanceIdentifier),
+				DBParameterGroupName: aws.String("test-parameter-group-2"),
+			}
+
+			_, err := rdsDBInstance.Modify(modifyDBInstanceInput)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(receivedModifyDBInstanceInput).ToNot(Equal(modifyDBInstanceInput))
+			Expect(receivedModifyDBInstanceInput.DBParameterGroupName).To(Equal(aws.String("test-parameter-group-2")))
 		})
 
 		Context("when describing the DB instance fails", func() {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/183378729

This pull request changes the way we update an existing rds instance. It removes the parameter group from the apply if the parameter group has not changed. This was suggested in the ticket as option 2. The logic is the same as the way we deal with a subnet group change.

By removing the parameter group before applying we don't get the status update from the aws api saying that it is "applying" a parameter group change. This mitigates the logic inside the broker which implies "applying" on a parameter group is the same as rebooting. See [sourrce code](https://github.com/alphagov/paas-rds-broker/blob/28e4b153809ba35345afddce5a7035b1e1c7215a/rdsbroker/broker.go#L1372).

We don't currently change existing parameter groups, so this should be a safe change. 