### PR TITLE
[#183975859] Allow users to get their broken service back on plan in a complex failure situation

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -6,7 +6,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/awsrds/rds_db_instance_test.go
+++ b/awsrds/rds_db_instance_test.go
@@ -1502,8 +1502,32 @@ var _ = Describe("RDS DB Instance", func() {
 					EngineVersion: aws.String("11"),
 				},
 			})
-			_, err := rdsDBInstance.GetFullValidTargetVersion("postgres", currentVersion, targetVersion)
+			version, err := rdsDBInstance.GetFullValidTargetVersion("postgres", currentVersion, targetVersion)
 			Expect(err).To(HaveOccurred())
+			Expect(version).To(Equal(""))
+		})
+
+		It("returns an empty string if the current and target major versions match with no available upgrades", func() {
+			engineVersions = dbEngineVersions("11.1", []*rds.UpgradeTarget{})
+			version, err := rdsDBInstance.GetFullValidTargetVersion("postgres", "11.1", "11")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(version).To(Equal(""))
+		})
+
+		It("returns an empty string if the current and target major versions match with no available major upgrades", func() {
+			engineVersions = dbEngineVersions("11.1", []*rds.UpgradeTarget{
+				{
+					Engine:        aws.String("postgres"),
+					EngineVersion: aws.String("12.4"),
+				},
+				{
+					Engine:        aws.String("postgres"),
+					EngineVersion: aws.String("12.5"),
+				},
+			})
+			version, err := rdsDBInstance.GetFullValidTargetVersion("postgres", "11.1", "11")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(version).To(Equal(""))
 		})
 
 		It("returns the newest minor version of the target major version", func() {

--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -731,9 +731,10 @@ func (b *RDSBroker) Update(
 			b.logger.Error("find-exact-upgrade-version", err)
 			return domain.UpdateServiceSpec{}, err
 		}
-
-		b.logger.Info("selected-upgrade-version", lager.Data{"version": targetVersion})
-		modifyDBInstanceInput.EngineVersion = aws.String(targetVersion)
+		if targetVersion != "" {
+			b.logger.Info("selected-upgrade-version", lager.Data{"version": targetVersion})
+			modifyDBInstanceInput.EngineVersion = aws.String(targetVersion)
+		}
 	}
 
 	updatedDBInstance, err := b.dbInstance.Modify(modifyDBInstanceInput)


### PR DESCRIPTION
What
----

This change fixes a particular issue a user found themselves in when trying to upgrade a database.

They had a "failed" upgrade which had actually succeeded in aws. In this particular case it was cause by the aws disk space issue.

They could not bring their service back on plan because there we no available updates for their minor version.

This changes allows them to perform the service update and essentially do a no-op upgrade in aws. This will only pass in the case of them having no available minor upgrades available and the major version matches the target version.

How to review
-------------

Look at the code.
Issue reproduced and fix tested in dev04