### PR TITLE
Add makefile option to bosh scp built binary to an existing bosh environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+# Temporary Build Files
+amd64/*
+
 # Dependency directories (remove the comment below to include it)
 # vendor/
 

--- a/Makefile
+++ b/Makefile
@@ -136,3 +136,11 @@ bosh_release:
 	@echo "    url: https://s3-${REGION}.amazonaws.com/$${BUCKET}/rds-broker-${VERSION}.tgz"
 	@echo "    sha1: $$(openssl sha1 "${TARBALL_PATH}" | cut -d' ' -f 2)"
 
+.PHONY: build_amd64
+build_amd64:
+	mkdir -p amd64
+	GOOS=linux GOARCH=amd64 go build -o amd64/paas-rds-broker
+
+.PHONY: bosh_scp
+bosh_scp: build_amd64
+	./scripts/bosh-scp.sh

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ $ rds-broker -config=<path-to-your-config-file>
 
 This broker can be deployed using the Bosh release built in this repository (`make bosh_release`). On the GOV.UK PaaS, the release is created in the `paas-rds-broker` pipeline of the CI env. 
 
+You can patch an existing bosh environment by first logging into a bosh director and running the following:
+
+```
+$ make bosh_scp
+```
+
 ## Configuration
 
 Refer to the [Configuration](https://github.com/alphagov/paas-rds-broker/blob/master/CONFIGURATION.md) instructions for details about configuring this broker.

--- a/scripts/bosh-scp.sh
+++ b/scripts/bosh-scp.sh
@@ -1,0 +1,31 @@
+#!/bin/bash 
+
+set -euo pipefail
+
+function run_command() {
+    local command=$1
+    local message=$2
+
+    echo -n "${message}... "
+
+    if ! output=$(bash -c "${command}" 2>&1); then
+        echo -e "failed.\n\n"
+        echo "Command Failed: ${command}"
+        echo ""
+        echo "Output: ${output}"
+        exit 1
+    fi
+    echo "done."
+}
+
+command -v jq >/dev/null 2>&1 || { echo >&2 "jq is required but it's not installed.  Aborting."; exit 1; }
+command -v bosh >/dev/null 2>&1 || { echo >&2 "bosh is required but it's not installed.  Aborting."; exit 1; }
+command -v cut >/dev/null 2>&1 || { echo >&2 "cut is required but it's not installed.  Aborting."; exit 1; }
+
+bosh vms --json | jq -r '.Tables[0].Rows[] | select(.instance|startswith("rds_broker/")) | .instance' | while read -r instance; do
+    run_command "bosh ssh ${instance} sudo monit stop rds-broker" "stopping rds-broker on ${instance}"
+    run_command "bosh scp ./amd64/paas-rds-broker ${instance}:/tmp/paas-rds-broker" "copying rds-broker binary to tmp on ${instance}"
+    run_command "bosh ssh ${instance} sudo mv /tmp/paas-rds-broker /var/vcap/packages/rds-broker/bin/paas-rds-broker" "moving paas-rds-broker binary from tmp to packages on ${instance}"
+    run_command "bosh ssh ${instance} sudo monit start rds-broker" "starting rds-broker on ${instance}"
+done
+


### PR DESCRIPTION
What
----

Add a make bosh_scp target for building and deploying into an existing environment.

Why
----

This allows a more rapid way to deploy and test your changes in an existing environment

How to review
-------------

Make sure it can go out through a dev env OK. It should be a no-op.

---