### PR TITLE
[#183944632] Add test cases to the broker after allowing for the aws storage to be greater than the plan.

### DIFF
--- a/awsrds/rds_db_instance.go
+++ b/awsrds/rds_db_instance.go
@@ -317,7 +317,10 @@ func (r *RDSDBInstance) Modify(modifyDBInstanceInput *rds.ModifyDBInstanceInput)
 	if modifyDBInstanceInput.AllocatedStorage != nil {
 		newAllocatedSpace := aws.Int64Value(modifyDBInstanceInput.AllocatedStorage)
 		oldAllocatedSpace := aws.Int64Value(oldDbInstance.AllocatedStorage)
-		if newAllocatedSpace <= oldAllocatedSpace {
+		if newAllocatedSpace == oldAllocatedSpace {
+			updatedModifyDBInstanceInput.AllocatedStorage = nil
+			r.logger.Info("modify-db-instance.storage-unchanged", lager.Data{"input": &sanitizedDBInstanceInput})
+		} else if newAllocatedSpace < oldAllocatedSpace {
 			updatedModifyDBInstanceInput.AllocatedStorage = nil
 			r.logger.Info("modify-db-instance.prevented-storage-downgrade", lager.Data{"input": &sanitizedDBInstanceInput})
 		}

--- a/ci/blackbox/config.json
+++ b/ci/blackbox/config.json
@@ -82,6 +82,39 @@
                             }
                         },
                         {
+                            "description": "Small plan without final snapshot - Postgres 10",
+                            "free": false,
+                            "id": "postgres-small-without-snapshot-10",
+                            "name": "small-without-snapshot-10",
+                            "rds_properties": {
+                                "allocated_storage": 13,
+                                "auto_minor_version_upgrade": true,
+                                "db_instance_class": "db.t2.micro",
+                                "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
+                                "engine": "postgres",
+                                "engine_version": "10",
+                                "engine_family": "postgres10",
+                                "multi_az": false,
+                                "skip_final_snapshot": true,
+                                "copy_tags_to_snapshot":true,
+                                "vpc_security_group_ids": [
+                                    "POPULATED_BY_TEST_SUITE"
+                                ],
+                                "default_extensions": [
+                                    "uuid-ossp",
+                                    "postgis",
+                                    "citext"
+                                ],
+                                "allowed_extensions": [
+                                    "uuid-ossp",
+                                    "tsearch2",
+                                    "postgis",
+                                    "citext",
+                                    "pg_stat_statements"
+                                ]
+                            }
+                        },
+                        {
                             "description": "Micro plan - Postgres 11",
                             "free": false,
                             "id": "postgres-micro-11",


### PR DESCRIPTION
What
----

As part [of a previous pull request](https://github.com/alphagov/paas-rds-broker/pull/164) we allowed the aws storage to be greater than the plan. The test cases were just adjusted to make them pass, as we needed to get a new build out to help a customer with an issue.

This pull requests adds additional unit and integration test around this situation.

Also tweak log messages around aws storage changes

How to review
-------------

Look at the code.