### PR TITLE
Removed mysql dbname to fix dropped db issue

### DIFF
--- a/sqlengine/mysql_engine.go
+++ b/sqlengine/mysql_engine.go
@@ -52,9 +52,9 @@ func checkMySQLIdentifierSafe(s string) error {
 func (d *MySQLEngine) Open(address string, port int64, dbname string, username string, password string) error {
 	logger := d.logger.Session("open")
 	logger.Debug("start")
-
-	connectionString := d.connectionString(address, port, dbname, username, password)
-	sanitizedConnectionString := d.connectionString(address, port, dbname, username, "REDACTED")
+	// leaving dbname blank in case it doesn't exist
+	connectionString := d.connectionString(address, port, "", username, password)
+	sanitizedConnectionString := d.connectionString(address, port, "", username, "REDACTED")
 	logger.Debug("sql-open", lager.Data{"connection-string": sanitizedConnectionString})
 
 	db, err := sql.Open("mysql", connectionString)


### PR DESCRIPTION
What
----

Replaced the dbname with empty quotes in the Open function of mysql_engine 

Why
----

This avoids failures when binding to a mysql service when the default db does not exist. The mysql_engine code does not require the dbname for any queries

How To Review
----

Look at the code