### PR TITLE
Integration tests post-pg10

### DIFF
--- a/ci/blackbox/config.json
+++ b/ci/blackbox/config.json
@@ -18,103 +18,6 @@
                     "plan_updateable": true,
                     "plans": [
                         {
-                            "description": "Micro plan - Postgres 10",
-                            "free": false,
-                            "id": "postgres-micro-10",
-                            "name": "micro-10",
-                            "rds_properties": {
-                                "allocated_storage": 10,
-                                "db_instance_class": "db.t2.micro",
-                                "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
-                                "engine": "postgres",
-                                "engine_version": "10",
-                                "engine_family": "postgres10",
-                                "multi_az": false,
-                                "copy_tags_to_snapshot":true,
-                                "vpc_security_group_ids": [
-                                    "POPULATED_BY_TEST_SUITE"
-                                ],
-                                "default_extensions": [
-                                    "uuid-ossp",
-                                    "postgis",
-                                    "citext"
-                                ],
-                                "allowed_extensions": [
-                                    "uuid-ossp",
-                                    "tsearch2",
-                                    "postgis",
-                                    "citext",
-                                    "pg_stat_statements"
-                                ]
-                            }
-                        },
-                        {
-                            "description": "Micro plan without final snapshot - Postgres 10",
-                            "free": false,
-                            "id": "postgres-micro-without-snapshot-10",
-                            "name": "micro-without-snapshot-10",
-                            "rds_properties": {
-                                "allocated_storage": 10,
-                                "auto_minor_version_upgrade": true,
-                                "db_instance_class": "db.t2.micro",
-                                "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
-                                "engine": "postgres",
-                                "engine_version": "10",
-                                "engine_family": "postgres10",
-                                "multi_az": false,
-                                "skip_final_snapshot": true,
-                                "copy_tags_to_snapshot":true,
-                                "vpc_security_group_ids": [
-                                    "POPULATED_BY_TEST_SUITE"
-                                ],
-                                "default_extensions": [
-                                    "uuid-ossp",
-                                    "postgis",
-                                    "citext"
-                                ],
-                                "allowed_extensions": [
-                                    "uuid-ossp",
-                                    "tsearch2",
-                                    "postgis",
-                                    "citext",
-                                    "pg_stat_statements"
-                                ]
-                            }
-                        },
-                        {
-                            "description": "Small plan without final snapshot - Postgres 10",
-                            "free": false,
-                            "id": "postgres-small-without-snapshot-10",
-                            "name": "small-without-snapshot-10",
-                            "rds_properties": {
-                                "allocated_storage": 13,
-                                "auto_minor_version_upgrade": true,
-                                "db_instance_class": "db.t2.micro",
-                                "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
-                                "engine": "postgres",
-                                "engine_version": "10",
-                                "engine_family": "postgres10",
-                                "multi_az": false,
-                                "skip_final_snapshot": true,
-                                "copy_tags_to_snapshot":true,
-                                "vpc_security_group_ids": [
-                                    "POPULATED_BY_TEST_SUITE"
-                                ],
-                                "default_extensions": [
-                                    "uuid-ossp",
-                                    "postgis",
-                                    "citext"
-                                ],
-                                "allowed_extensions": [
-                                    "uuid-ossp",
-                                    "tsearch2",
-                                    "postgis",
-                                    "citext",
-                                    "pg_stat_statements"
-                                ]
-                            }
-                        },
-                        {
                             "description": "Micro plan - Postgres 11",
                             "free": false,
                             "id": "postgres-micro-11",
@@ -271,6 +174,38 @@
                             }
                         },
                         {
+                            "description": "Small plan without final snapshot - Postgres 12",
+                            "free": false,
+                            "id": "postgres-small-without-snapshot-12",
+                            "name": "small-without-snapshot-12",
+                            "rds_properties": {
+                                "allocated_storage": 15,
+                                "auto_minor_version_upgrade": true,
+                                "db_instance_class": "db.t3.micro",
+                                "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
+                                "engine": "postgres",
+                                "engine_version": "12",
+                                "engine_family": "postgres12",
+                                "multi_az": false,
+                                "skip_final_snapshot": true,
+                                "copy_tags_to_snapshot":true,
+                                "vpc_security_group_ids": [
+                                    "POPULATED_BY_TEST_SUITE"
+                                ],
+                                "default_extensions": [
+                                    "uuid-ossp",
+                                    "postgis",
+                                    "citext"
+                                ],
+                                "allowed_extensions": [
+                                    "uuid-ossp",
+                                    "postgis",
+                                    "citext",
+                                    "pg_stat_statements"
+                                ]
+                            }
+                        },
+                        {
                             "description": "Micro plan - Postgres 13",
                             "free": false,
                             "id": "postgres-micro-13",
@@ -307,6 +242,38 @@
                             "name": "micro-without-snapshot-13",
                             "rds_properties": {
                                 "allocated_storage": 10,
+                                "auto_minor_version_upgrade": true,
+                                "db_instance_class": "db.t3.micro",
+                                "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
+                                "engine": "postgres",
+                                "engine_version": "13",
+                                "engine_family": "postgres13",
+                                "multi_az": false,
+                                "skip_final_snapshot": true,
+                                "copy_tags_to_snapshot":true,
+                                "vpc_security_group_ids": [
+                                    "POPULATED_BY_TEST_SUITE"
+                                ],
+                                "default_extensions": [
+                                    "uuid-ossp",
+                                    "postgis",
+                                    "citext"
+                                ],
+                                "allowed_extensions": [
+                                    "uuid-ossp",
+                                    "postgis",
+                                    "citext",
+                                    "pg_stat_statements"
+                                ]
+                            }
+                        },
+                        {
+                            "description": "Small plan without final snapshot - Postgres 13",
+                            "free": false,
+                            "id": "postgres-small-without-snapshot-13",
+                            "name": "small-without-snapshot-13",
+                            "rds_properties": {
+                                "allocated_storage": 15,
                                 "auto_minor_version_upgrade": true,
                                 "db_instance_class": "db.t3.micro",
                                 "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",

--- a/ci/blackbox/rdsbroker_test.go
+++ b/ci/blackbox/rdsbroker_test.go
@@ -80,7 +80,7 @@ var _ = Describe("RDS Broker Daemon", func() {
 			Expect(service2.Description).To(Equal("AWS RDS PostgreSQL service"))
 			Expect(service2.Bindable).To(BeTrue())
 			Expect(service2.PlanUpdatable).To(BeTrue())
-			Expect(service2.Plans).To(HaveLen(10))
+			Expect(service2.Plans).To(HaveLen(9))
 		})
 	})
 
@@ -221,8 +221,8 @@ var _ = Describe("RDS Broker Daemon", func() {
 			})
 		}
 
-		Describe("Postgres 10", func() {
-			TestProvisionBindDeprovision("postgres", "postgres-micro-without-snapshot-10")
+		Describe("Postgres 11", func() {
+			TestProvisionBindDeprovision("postgres", "postgres-micro-without-snapshot-11")
 		})
 
 		Describe("Postgres 13", func() {
@@ -319,8 +319,8 @@ var _ = Describe("RDS Broker Daemon", func() {
 			})
 		}
 
-		Describe("Postgres 10", func() {
-			TestUpdateExtensions("postgres", "postgres-micro-without-snapshot-10")
+		Describe("Postgres 11", func() {
+			TestUpdateExtensions("postgres", "postgres-micro-without-snapshot-11")
 		})
 
 		Describe("Postgres 13", func() {
@@ -364,10 +364,6 @@ var _ = Describe("RDS Broker Daemon", func() {
 				Expect(state).To(Equal("succeeded"))
 			})
 		}
-
-		Describe("Postgres 10 to 11", func() {
-			TestUpdatePlan("postgres", "postgres-micro-without-snapshot-10", "postgres-micro-without-snapshot-11")
-		})
 
 		Describe("Postgres 11 to 12", func() {
 			TestUpdatePlan("postgres", "postgres-micro-without-snapshot-11", "postgres-micro-without-snapshot-12")
@@ -500,32 +496,32 @@ var _ = Describe("RDS Broker Daemon", func() {
 			})
 		}
 
-		Describe("Postgres 10 to 11 clean failure", func() {
+		Describe("Postgres 11 to 12 clean failure", func() {
 			// postgresSabotageUpgrade-caused failure shouldn't have produced
 			// any lasting effects and plan id should have been rolled back
 			TestUpdatePlan(
 				"postgres",
-				"postgres-micro-without-snapshot-10",
 				"postgres-micro-without-snapshot-11",
-				"postgres-micro-without-snapshot-10",
+				"postgres-micro-without-snapshot-12",
+				"postgres-micro-without-snapshot-11",
 				"",
 			)
 		})
 
-		Describe("Postgres 10 to 11 failure resulting in over-allocated disk", func() {
-			// the test upgrades from postgres 10 to 11, which fails due to
+		Describe("Postgres 11 to 12 failure resulting in over-allocated disk", func() {
+			// this test upgrades from postgres 11 to 12, which fails due to
 			// postgresSabotageUpgrade's actions. this will leave the aws
 			// storage over-allocated with 15gb instead of 10gb.
 			//
-			// the test then moves to another postgres 10 plan which still
+			// the test then moves to another postgres 11 plan which still
 			// (in theory) has less disk space than we now actually have
 			// (13gb), but should succeed.
 			TestUpdatePlan(
 				"postgres",
-				"postgres-micro-without-snapshot-10",
+				"postgres-micro-without-snapshot-11",
+				"postgres-small-without-snapshot-12",
+				"postgres-micro-without-snapshot-11",
 				"postgres-small-without-snapshot-11",
-				"postgres-micro-without-snapshot-10",
-				"postgres-small-without-snapshot-10",
 			)
 		})
 	})
@@ -668,8 +664,8 @@ var _ = Describe("RDS Broker Daemon", func() {
 			})
 		}
 
-		Describe("Postgres 10", func() {
-			TestFinalSnapshot("postgres", "postgres-micro-10")
+		Describe("Postgres 11", func() {
+			TestFinalSnapshot("postgres", "postgres-micro-11")
 		})
 
 		Describe("Postgres 13", func() {
@@ -849,8 +845,8 @@ var _ = Describe("RDS Broker Daemon", func() {
 			})
 		}
 
-		Describe("Postgres 10", func() {
-			TestRestoreFromSnapshot("postgres", "postgres-micro-10", true)
+		Describe("Postgres 11", func() {
+			TestRestoreFromSnapshot("postgres", "postgres-micro-11", true)
 		})
 
 		Describe("Postgres 13", func() {
@@ -1021,8 +1017,8 @@ var _ = Describe("RDS Broker Daemon", func() {
 			})
 		}
 
-		Describe("Postgres 10", func() {
-			TestRestoreFromPointInTime("postgres", "postgres-micro-10", true)
+		Describe("Postgres 11", func() {
+			TestRestoreFromPointInTime("postgres", "postgres-micro-11", true)
 		})
 
 		Describe("Postgres 13", func() {

--- a/ci/blackbox/rdsbroker_test.go
+++ b/ci/blackbox/rdsbroker_test.go
@@ -431,21 +431,39 @@ var _ = Describe("RDS Broker Daemon", func() {
 	})
 
 	Describe("plan upgrade failures and recovery", func() {
-		TestUpdatePlan := func(serviceID, startPlanID, upgradeToPlanID, extensionName, expectedAwsTagPlanID, recoveryPlanID string) {
+		TestUpdatePlan := func(serviceID, startPlanID, upgradeToPlanID, expectedAwsTagPlanID, recoveryPlanID string) {
 			var (
 				instanceID string
+				appGUID    string
+				bindingID  string
 			)
 
 			BeforeEach(func() {
 				instanceID = uuid.NewV4().String()
+				appGUID = uuid.NewV4().String()
+				bindingID = uuid.NewV4().String()
 
 				brokerAPIClient.AcceptsIncomplete = true
 
-				code, operation, err := brokerAPIClient.ProvisionInstance(instanceID, serviceID, startPlanID, fmt.Sprintf(`{"enable_extensions": ["%s"]}`, extensionName))
+				code, operation, err := brokerAPIClient.ProvisionInstance(instanceID, serviceID, startPlanID, `{}`)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(code).To(Equal(202))
 				state := pollForOperationCompletion(brokerAPIClient, instanceID, serviceID, startPlanID, operation)
 				Expect(state).To(Equal("succeeded"))
+
+				resp, err := brokerAPIClient.DoBindRequest(instanceID, serviceID, startPlanID, appGUID, bindingID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(201))
+
+				credentials, err := getCredentialsFromBindResponse(resp)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = postgresSabotageUpgrade(credentials.URI)
+				Expect(err).ToNot(HaveOccurred())
+
+				resp, err = brokerAPIClient.DoUnbindRequest(instanceID, serviceID, startPlanID, bindingID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(200))
 			})
 
 			AfterEach(func() {
@@ -482,33 +500,30 @@ var _ = Describe("RDS Broker Daemon", func() {
 			})
 		}
 
-		// tsearch2 isn't available on postgres > 10, hence will produce a
-		// reliable failure on upgrade
-
 		Describe("Postgres 10 to 11 clean failure", func() {
-			// tsearch2-caused failure shouldn't have caused any lasting effects
-			// and plan id should have been rolled back
+			// postgresSabotageUpgrade-caused failure shouldn't have produced
+			// any lasting effects and plan id should have been rolled back
 			TestUpdatePlan(
 				"postgres",
 				"postgres-micro-without-snapshot-10",
 				"postgres-micro-without-snapshot-11",
-				"tsearch2",
 				"postgres-micro-without-snapshot-10",
 				"",
 			)
 		})
 
 		Describe("Postgres 10 to 11 failure resulting in over-allocated disk", func() {
-			// the test upgrades from postgres 10 to 11, which fails due to the tsearch2 extension
-			// being unavailable on postgres 11. This will leave the aws storage over-allocated with
-			// 15gb instead of 10gb.
-			// The test then moves to another postgres 10 plan which still (in theory) has less disk space than we now actually have
+			// the test upgrades from postgres 10 to 11, which fails due to
+			// postgresSabotageUpgrade's actions. this will leave the aws
+			// storage over-allocated with 15gb instead of 10gb.
+			//
+			// the test then moves to another postgres 10 plan which still
+			// (in theory) has less disk space than we now actually have
 			// (13gb), but should succeed.
 			TestUpdatePlan(
 				"postgres",
 				"postgres-micro-without-snapshot-10",
 				"postgres-small-without-snapshot-11",
-				"tsearch2",
 				"postgres-micro-without-snapshot-10",
 				"postgres-small-without-snapshot-10",
 			)
@@ -1257,6 +1272,21 @@ func postgresExtensionsTest(databaseURI string) error {
 	default:
 		return fmt.Errorf("Scheme must either be postgres or mysql")
 	}
+
+	return nil
+}
+
+func postgresSabotageUpgrade(databaseURI string) error {
+	db, err := openConnection(databaseURI)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	// use of regoperator or other OID-referencing data types should
+	// cause a postgres version upgrade to consistently fail.
+	_, err = db.Exec("CREATE TABLE works ( spanner regoperator )")
+	Expect(err).ToNot(HaveOccurred())
 
 	return nil
 }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/184149459

PostgreSQL 10 will not be available on RDS from February. If we don't act, our integration tests will break as they use PostgreSQL 10 for a number of tests.

It's not quite as simple as exchanging uses of PostgreSQL 10 for 11, because we relied having a pg version that supported an extension which the next version up did not (in this case `tsearch2`) to test upgrade failures. With there not being any other extension with this property in the remaining PostgreSQL versions we support, we needed a new way to trigger this failure. OID-referencing data-types like `regoperator` will prevent upgrades from working successfully, so create `postgresSabotageUpgrade()` which creates a table using this data-type to throw a spanner in the works when we need it.

Then this goes ahead and removes all uses of PostgreSQL 10 in the integration tests.