### PR TITLE
[#184325652] Add error message and integration test when the rds storage is full

### DIFF
--- a/ci/blackbox/config.json
+++ b/ci/blackbox/config.json
@@ -23,7 +23,7 @@
                             "id": "postgres-micro-11",
                             "name": "micro-11",
                             "rds_properties": {
-                                "allocated_storage": 10,
+                                "allocated_storage": 5,
                                 "db_instance_class": "db.t3.micro",
                                 "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
                                 "engine": "postgres",
@@ -53,7 +53,7 @@
                             "id": "postgres-micro-without-snapshot-11",
                             "name": "micro-without-snapshot-11",
                             "rds_properties": {
-                                "allocated_storage": 10,
+                                "allocated_storage": 5,
                                 "auto_minor_version_upgrade": true,
                                 "db_instance_class": "db.t3.micro",
                                 "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
@@ -85,7 +85,7 @@
                             "id": "postgres-small-without-snapshot-11",
                             "name": "small-without-snapshot-11",
                             "rds_properties": {
-                                "allocated_storage": 15,
+                                "allocated_storage": 10,
                                 "auto_minor_version_upgrade": true,
                                 "db_instance_class": "db.t3.micro",
                                 "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
@@ -117,7 +117,7 @@
                             "id": "postgres-micro-12",
                             "name": "micro-12",
                             "rds_properties": {
-                                "allocated_storage": 10,
+                                "allocated_storage": 5,
                                 "db_instance_class": "db.t3.micro",
                                 "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
                                 "engine": "postgres",
@@ -147,7 +147,7 @@
                             "id": "postgres-micro-without-snapshot-12",
                             "name": "micro-without-snapshot-12",
                             "rds_properties": {
-                                "allocated_storage": 10,
+                                "allocated_storage": 5,
                                 "auto_minor_version_upgrade": true,
                                 "db_instance_class": "db.t3.micro",
                                 "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
@@ -179,7 +179,7 @@
                             "id": "postgres-small-without-snapshot-12",
                             "name": "small-without-snapshot-12",
                             "rds_properties": {
-                                "allocated_storage": 15,
+                                "allocated_storage": 10,
                                 "auto_minor_version_upgrade": true,
                                 "db_instance_class": "db.t3.micro",
                                 "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
@@ -211,7 +211,7 @@
                             "id": "postgres-micro-13",
                             "name": "micro-13",
                             "rds_properties": {
-                                "allocated_storage": 10,
+                                "allocated_storage": 5,
                                 "db_instance_class": "db.t3.micro",
                                 "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
                                 "engine": "postgres",
@@ -241,7 +241,7 @@
                             "id": "postgres-micro-without-snapshot-13",
                             "name": "micro-without-snapshot-13",
                             "rds_properties": {
-                                "allocated_storage": 10,
+                                "allocated_storage": 5,
                                 "auto_minor_version_upgrade": true,
                                 "db_instance_class": "db.t3.micro",
                                 "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
@@ -263,7 +263,8 @@
                                     "uuid-ossp",
                                     "postgis",
                                     "citext",
-                                    "pg_stat_statements"
+                                    "pg_stat_statements",
+                                    "pgcrypto"
                                 ]
                             }
                         },
@@ -273,9 +274,9 @@
                             "id": "postgres-small-without-snapshot-13",
                             "name": "small-without-snapshot-13",
                             "rds_properties": {
-                                "allocated_storage": 15,
+                                "allocated_storage": 10,
                                 "auto_minor_version_upgrade": true,
-                                "db_instance_class": "db.t3.micro",
+                                "db_instance_class": "db.t3.small",
                                 "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
                                 "engine": "postgres",
                                 "engine_version": "13",
@@ -295,7 +296,8 @@
                                     "uuid-ossp",
                                     "postgis",
                                     "citext",
-                                    "pg_stat_statements"
+                                    "pg_stat_statements",
+                                    "pgcrypto"
                                 ]
                             }
                         }

--- a/ci/helpers/aws_helper.go
+++ b/ci/helpers/aws_helper.go
@@ -1,17 +1,18 @@
 package helpers
 
 import (
-	"code.cloudfoundry.org/lager"
 	"fmt"
-	"golang.org/x/sync/errgroup"
 	"strings"
+
+	"code.cloudfoundry.org/lager"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/rds"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 )
 
 func CreateSubnetGroup(prefix string, session *session.Session) (*string, error) {
@@ -85,6 +86,17 @@ func CreateSecurityGroup(prefix string, session *session.Session) (*string, erro
 	}
 
 	return securityGroup.GroupId, nil
+}
+
+func GetRDSStatus(instanceID string, session *session.Session) (string, error) {
+	rdsService := rds.New(session)
+	instance, err := rdsService.DescribeDBInstances(&rds.DescribeDBInstancesInput{
+		DBInstanceIdentifier: aws.String(instanceID),
+	})
+	if err != nil {
+		return "", err
+	}
+	return aws.StringValue(instance.DBInstances[0].DBInstanceStatus), nil
 }
 
 func DestroySubnetGroup(name *string, session *session.Session, logger lager.Logger) error {

--- a/ci/helpers/rdsclient_helper.go
+++ b/ci/helpers/rdsclient_helper.go
@@ -26,7 +26,7 @@ func NewRDSClient(region string, dbPrefix string) (*RDSClient, error) {
 	}, nil
 }
 
-func (b *RDSClient) dbInstanceIdentifier(instanceID string) string {
+func (b *RDSClient) DbInstanceIdentifier(instanceID string) string {
 	return fmt.Sprintf("%s-%s", strings.Replace(b.dbPrefix, "_", "-", -1), strings.Replace(instanceID, "_", "-", -1))
 }
 
@@ -35,7 +35,7 @@ func (b *RDSClient) dbInstanceIdentifierToServiceInstanceID(serviceInstanceID st
 }
 
 func (b *RDSClient) DBInstanceFinalSnapshotIdentifier(instanceID string) string {
-	return b.dbInstanceIdentifier(instanceID) + "-final-snapshot"
+	return b.DbInstanceIdentifier(instanceID) + "-final-snapshot"
 }
 
 func (r *RDSClient) Ping() (bool, error) {
@@ -64,7 +64,7 @@ func (r *RDSClient) UpgradeEngine(ID string, engineVersion string, parameterGrou
 	}
 
 	params := &rds.ModifyDBInstanceInput{
-		DBInstanceIdentifier:     aws.String(r.dbInstanceIdentifier(ID)),
+		DBInstanceIdentifier:     aws.String(r.DbInstanceIdentifier(ID)),
 		EngineVersion:            aws.String(engineVersion),
 		AllowMajorVersionUpgrade: aws.Bool(true),
 		ApplyImmediately:         aws.Bool(true),
@@ -80,10 +80,10 @@ func (r *RDSClient) UpgradeEngine(ID string, engineVersion string, parameterGrou
 }
 
 func (r *RDSClient) CreateDBSnapshot(ID string) (string, error) {
-	snapshotID := r.dbInstanceIdentifier(ID) + time.Now().Format("2006-01-02-15-04")
+	snapshotID := r.DbInstanceIdentifier(ID) + time.Now().Format("2006-01-02-15-04")
 
 	params := &rds.CreateDBSnapshotInput{
-		DBInstanceIdentifier: aws.String(r.dbInstanceIdentifier(ID)),
+		DBInstanceIdentifier: aws.String(r.DbInstanceIdentifier(ID)),
 		DBSnapshotIdentifier: aws.String(snapshotID),
 	}
 
@@ -123,7 +123,7 @@ func (r *RDSClient) DeleteDBSnapshot(snapshotID string) (*rds.DeleteDBSnapshotOu
 
 func (r *RDSClient) GetDBInstanceDetails(ID string) (*rds.DescribeDBInstancesOutput, error) {
 	params := &rds.DescribeDBInstancesInput{
-		DBInstanceIdentifier: aws.String(r.dbInstanceIdentifier(ID)),
+		DBInstanceIdentifier: aws.String(r.DbInstanceIdentifier(ID)),
 	}
 
 	return r.rdssvc.DescribeDBInstances(params)

--- a/rdsbroker/broker.go
+++ b/rdsbroker/broker.go
@@ -636,6 +636,12 @@ func (b *RDSBroker) Update(
 		return domain.UpdateServiceSpec{}, fmt.Errorf("cannot find instance %s", b.dbInstanceIdentifier(instanceID))
 	}
 
+	if aws.StringValue(existingInstance.DBInstanceStatus) == "storage-full" {
+		return domain.UpdateServiceSpec{},
+				fmt.Errorf("Cannot update instance %s because it is in state \"storage-full\". You will need to contact support to resolve this issue.",
+				b.dbInstanceIdentifier(instanceID))
+	}
+
 	previousDbParamGroup := *existingInstance.DBParameterGroups[0].DBParameterGroupName
 
 	newDbParamGroup := previousDbParamGroup

--- a/rdsbroker/broker_update_test.go
+++ b/rdsbroker/broker_update_test.go
@@ -530,6 +530,26 @@ var _ = Describe("RDS Broker", func() {
 			})
 		})
 
+		Context("when rds state is in state storage-full", func() {
+
+			It("returns a contact support error", func() {
+				existingDbInstance = &rds.DBInstance{
+					DBParameterGroups: []*rds.DBParameterGroupStatus{
+						&rds.DBParameterGroupStatus{
+							DBParameterGroupName: aws.String("originalParameterGroupName"),
+						},
+					},
+					Engine:        stringPointer("test-engine-one"),
+					EngineVersion: stringPointer("1.2.3"),
+					DBInstanceStatus: aws.String("storage-full"),
+				}
+				rdsInstance.DescribeReturns(existingDbInstance, nil)
+				_, err := rdsBroker.Update(ctx, instanceID, updateDetails, acceptsIncomplete)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("You will need to contact support to resolve this issue."))
+			})
+		})
+
 		Context("when has CopyTagsToSnapshot", func() {
 			BeforeEach(func() {
 				rdsProperties2.CopyTagsToSnapshot = boolPointer(true)


### PR DESCRIPTION
What
----

Adds error message to tell the user they need to contact support when they get into the situation of storage-full. Adds unit and integration tests around this scenario.

Sadly there is currently no way for them to resolve this issue themselves.

How to Review
----

Look at the code.

Who can review
----

Team member familiar with the rds broker.