### PR TITLE
Remove MySQL 5.7 usage from tests

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -39,7 +39,3 @@ jobs:
       - name: Run mysql 8.0
         run: |
           make start_mysql_80 run_mysql_sql_tests stop_mysql_80
-
-      - name: Run mysql 5.7
-        run: |
-          make start_mysql_57 run_mysql_sql_tests stop_mysql_57

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ test_all_sql: test_postgres test_mysql
 .PHONY: test_postgres
 test_postgres: start_postgres_10 run_postgres_sql_tests stop_postgres_10 start_postgres_11 run_postgres_sql_tests stop_postgres_11 start_postgres_12 run_postgres_sql_tests stop_postgres_12 start_postgres_13 run_postgres_sql_tests stop_postgres_13
 .PHONY: test_mysql
-test_mysql: start_mysql_80 run_mysql_sql_tests stop_mysql_80 start_mysql_57 run_mysql_sql_tests stop_mysql_57
+test_mysql: start_mysql_80 run_mysql_sql_tests stop_mysql_80
 
 .PHONY: run_mysql_sql_tests
 run_mysql_sql_tests:
@@ -66,14 +66,6 @@ stop_postgres_12:
 stop_postgres_13:
 	docker rm -f postgres-13
 
-.PHONY: start_mysql_57
-start_mysql_57:
-	docker run -p 3307:3306 --name mysql-57 -e MYSQL_ROOT_PASSWORD=$(MYSQL_PASSWORD) -d mysql:5.7; \
-	until docker exec mysql-57 mysqladmin ping --silent; do \
-	    printf "."; sleep 1;                             \
-	done; \
-	sleep 5
-
 .PHONY: start_mysql_80
 start_mysql_80:
 	docker run -p 3307:3306 --name mysql-80 -e MYSQL_ROOT_PASSWORD=$(MYSQL_PASSWORD) -d mysql:8.0 \
@@ -83,17 +75,12 @@ start_mysql_80:
 	done; \
 	sleep 5
 
-.PHONY: stop_mysql_57
-stop_mysql_57:
-	docker rm -f mysql-57
-
 .PHONY: stop_mysql_80
 stop_mysql_80:
 	docker rm -f mysql-80
 
 .PHONY: stop_dbs
 stop_dbs:
-	docker rm -f mysql-57 || true
 	docker rm -f mysql-80 || true
 	docker rm -f postgres-10 || true
 	docker rm -f postgres-11 || true

--- a/awsrds/rds_db_instance_test.go
+++ b/awsrds/rds_db_instance_test.go
@@ -1608,8 +1608,6 @@ var _ = Describe("RDS DB Instance", func() {
 			Entry("postgres 9.5->10", "postgres", "9.5", "10", "10.6", "10.6"),
 			Entry("postgres 9.5->11", "postgres", "9.5", "11", "11.5", "11.5"),
 			Entry("postgres 9.5->12", "postgres", "9.5", "12", "12.4", "12.4"),
-			Entry("mysql 5.5->5.7", "mysql", "5.5", "5.7", "5.7.22", "5.7.22"),
-			Entry("mysql 5.7->8.0", "mysql", "5.7", "8.0", "8.0.20", "8.0.20"),
 		)
 	})
 })

--- a/ci/blackbox/config.json
+++ b/ci/blackbox/config.json
@@ -310,47 +310,6 @@
                     "plan_updateable": true,
                     "plans": [
                         {
-                            "description": "Micro plan - mysql 5.7",
-                            "free": false,
-                            "id": "mysql-5.7-micro",
-                            "name": "micro-5.7",
-                            "rds_properties": {
-                                "allocated_storage": 10,
-                                "db_instance_class": "db.t2.micro",
-                                "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
-                                "engine": "mysql",
-                                "engine_version": "5.7",
-                                "engine_family": "mysql5.7",
-                                "multi_az": false,
-                                "copy_tags_to_snapshot":true,
-                                "vpc_security_group_ids": [
-                                    "POPULATED_BY_TEST_SUITE"
-                                ]
-                            }
-                        },
-                        {
-                            "description": "Micro plan mysql 5.7 without final snapshot",
-                            "free": false,
-                            "id": "mysql-5.7-micro-without-snapshot",
-                            "name": "micro-5.7-without-snapshot",
-                            "rds_properties": {
-                                "allocated_storage": 10,
-                                "auto_minor_version_upgrade": true,
-                                "db_instance_class": "db.t2.micro",
-                                "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
-                                "engine": "mysql",
-                                "engine_version": "5.7",
-                                "engine_family": "mysql5.7",
-                                "multi_az": false,
-                                "skip_final_snapshot": true,
-                                "copy_tags_to_snapshot":true,
-                                "vpc_security_group_ids": [
-                                    "POPULATED_BY_TEST_SUITE"
-                                ]
-                            }
-                        },
-
-                        {
                             "description": "Micro plan - mysql 8.0",
                             "free": false,
                             "id": "mysql-8.0-micro",

--- a/ci/blackbox/rdsbroker_test.go
+++ b/ci/blackbox/rdsbroker_test.go
@@ -76,7 +76,7 @@ var _ = Describe("RDS Broker Daemon", func() {
 			Expect(service1.Description).To(Equal("AWS RDS MySQL service"))
 			Expect(service1.Bindable).To(BeTrue())
 			Expect(service1.PlanUpdatable).To(BeTrue())
-			Expect(service1.Plans).To(HaveLen(4))
+			Expect(service1.Plans).To(HaveLen(2))
 
 			Expect(service2.ID).To(Equal("postgres"))
 			Expect(service2.Name).To(Equal("postgres"))
@@ -232,10 +232,6 @@ var _ = Describe("RDS Broker Daemon", func() {
 			TestProvisionBindDeprovision("postgres", "postgres-micro-without-snapshot-13")
 		})
 
-		Describe("MySQL 5.7", func() {
-			TestProvisionBindDeprovision("mysql", "mysql-5.7-micro-without-snapshot")
-		})
-
 		Describe("MySQL 8.0", func() {
 			TestProvisionBindDeprovision("mysql", "mysql-8.0-micro-without-snapshot")
 		})
@@ -374,10 +370,6 @@ var _ = Describe("RDS Broker Daemon", func() {
 
 		Describe("Postgres 12 to 13", func() {
 			TestUpdatePlan("postgres", "postgres-micro-without-snapshot-12", "postgres-micro-without-snapshot-13")
-		})
-
-		Describe("MySQL 5.7 to 8.0", func() {
-			TestUpdatePlan("mysql", "mysql-5.7-micro-without-snapshot", "mysql-8.0-micro-without-snapshot")
 		})
 	})
 
@@ -743,10 +735,6 @@ var _ = Describe("RDS Broker Daemon", func() {
 			TestFinalSnapshot("postgres", "postgres-micro-13")
 		})
 
-		Describe("MySQL 5.7", func() {
-			TestFinalSnapshot("mysql", "mysql-5.7-micro")
-		})
-
 		Describe("MySQL 8.0", func() {
 			TestFinalSnapshot("mysql", "mysql-8.0-micro")
 		})
@@ -924,10 +912,6 @@ var _ = Describe("RDS Broker Daemon", func() {
 			TestRestoreFromSnapshot("postgres", "postgres-micro-13", true)
 		})
 
-		Describe("MySQL 5.7", func() {
-			TestRestoreFromSnapshot("mysql", "mysql-5.7-micro", false)
-		})
-
 		Describe("MySQL 8.0", func() {
 			TestRestoreFromSnapshot("mysql", "mysql-8.0-micro", false)
 		})
@@ -1094,10 +1078,6 @@ var _ = Describe("RDS Broker Daemon", func() {
 
 		Describe("Postgres 13", func() {
 			TestRestoreFromPointInTime("postgres", "postgres-micro-13", true)
-		})
-
-		Describe("MySQL 5.7", func() {
-			TestRestoreFromPointInTime("mysql", "mysql-5.7-micro", false)
 		})
 
 		Describe("MySQL 8.0", func() {

--- a/rdsbroker/supported_extensions.go
+++ b/rdsbroker/supported_extensions.go
@@ -127,6 +127,4 @@ var SupportedPreloadExtensions = map[string][]DBExtension{
 			RequiresPreloadLibrary: true,
 		},
 	},
-
-	"mysql5.7": []DBExtension{},
 }


### PR DESCRIPTION
The integration tests are now failing because they try to create MySQL 5.7 databases, and MySQL 5.7 is now only available through RDS Extended Support: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.Concepts.VersionMgmt.html

We have already disabled MySQL 5.7 from the catalogue in https://github.com/alphagov/paas-cf/pull/3571