### PR TITLE
Update to go 1.22

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -1,7 +1,7 @@
 name: Go
 on: [push, pull_request]
 env:
-  GO_VERSION: "1.21"
+  GO_VERSION: "1.22"
 jobs:
   build:
     name: Build

--- a/ci/integration.yml
+++ b/ci/integration.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: "1.21"
+    tag: "1.22"
 inputs:
   - name: repo
     path: src/github.com/alphagov/paas-rds-broker

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alphagov/paas-rds-broker
 
-go 1.21
+go 1.22
 
 require (
 	github.com/Masterminds/semver v1.5.0

--- a/release/packages/rds-broker/packaging
+++ b/release/packages/rds-broker/packaging
@@ -2,7 +2,7 @@ set -e # exit immediately if a simple command exits with a non-zero status
 set -u # report the usage of uninitialized variables
 
 # Set Golang dependency
-source /var/vcap/packages/golang-1.21-linux/bosh/compile.env
+source /var/vcap/packages/golang-1.22-linux/bosh/compile.env
 export GOCACHE=/tmp/gocache
 
 # Build AWS RDS Service Broker package

--- a/release/packages/rds-broker/spec
+++ b/release/packages/rds-broker/spec
@@ -1,6 +1,6 @@
 ---
 name: rds-broker
 dependencies:
-  - golang-1.21-linux
+  - golang-1.22-linux
 files:
   - github.com/alphagov/paas-rds-broker/**/*

--- a/release/packages/rds-metric-collector/packaging
+++ b/release/packages/rds-metric-collector/packaging
@@ -2,7 +2,7 @@ set -e # exit immediately if a simple command exits with a non-zero status
 set -u # report the usage of uninitialized variables
 
 # Set Golang dependency
-source /var/vcap/packages/golang-1.21-linux/bosh/compile.env
+source /var/vcap/packages/golang-1.22-linux/bosh/compile.env
 export GOCACHE=/tmp/gocache
 
 # Build AWS RDS Metric Collector package

--- a/release/packages/rds-metric-collector/spec
+++ b/release/packages/rds-metric-collector/spec
@@ -1,6 +1,6 @@
 ---
 name: rds-metric-collector
 dependencies:
-  - golang-1.21-linux
+  - golang-1.22-linux
 files:
   - github.com/alphagov/paas-rds-metric-collector/**/*

--- a/release/vendor-packaging.yml
+++ b/release/vendor-packaging.yml
@@ -2,5 +2,5 @@
 packaged_release:
   name: bosh-package-golang-release
   repo: https://github.com/cloudfoundry/bosh-package-golang-release.git
-  package: golang-1.21-linux
+  package: golang-1.22-linux
   tag: v0.147.0


### PR DESCRIPTION
## What

Use go v1.22

## Why

To be compatible with go buildpack upgrades

## How to review

Ensure that the rds broker deploys okay to a dev environment and passes tests

## Who can review

Current PaaS team members

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨